### PR TITLE
Unify delta dispatch, dedup helpers, generalize left-join pushdown, batch metadata

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ Never execute git commands that could lose code. Always ask the user for permiss
 - **Every IVM refresh in a test MUST be cross-checked** with `EXCEPT ALL` in both directions to verify full bag equality between the MV and the base query. Never just check COUNT or specific values.
 - **Stress tests must batch many conflicting DML ops** (INSERT + DELETE + UPDATE on same rows) before a single refresh. Don't do 1 insert → refresh → 1 delete → refresh — that's not testing delta consolidation.
 - **Before implementing anything, search the existing codebase** for similar patterns or solutions. Check if a helper function, utility, or prior approach already addresses the problem. Reuse before reinventing.
-- **Use helper functions.** Factor shared logic into helpers rather than duplicating code. Check `src/include/rules/rule.hpp`, `src/rules/helpers.cpp`, and `src/include/core/sql_utils.hpp` for existing utilities.
+- **Use helper functions.** Factor shared logic into helpers rather than duplicating code. Check `src/delta/delta_helpers.cpp`, `src/upsert/refresh_helpers.cpp`, and `src/include/core/sql_utils.hpp` for existing utilities.
 - **Never edit the `duckdb/` submodule.** The DuckDB source is read-only. All IVM logic lives in `src/` and `test/`. If you need DuckDB internals, use the public API or ask the user.
 - **Keep the paper in mind.** OpenIVM is described in [OpenIVM: a SQL-to-SQL Compiler for Incremental Computations](https://arxiv.org/abs/2404.16486). Refer to it for the theoretical foundations (DBSP framework, Z-sets, delta rules) before making changes to core rewrite or upsert logic.
 - **Add `OPENIVM_DEBUG_PRINT` statements** at major code flow points (entry/exit of rewrite rules, upsert compilation, cost model decisions). Use the existing `OPENIVM_DEBUG_PRINT` macro from `src/include/core/openivm_debug.hpp` — it's compiled out when `OPENIVM_DEBUG` is 0.
@@ -62,24 +62,39 @@ When `PRAGMA refresh('view_name')` is called:
 2. **Upsert compilation** generates SQL to apply the deltas to the materialized view
 3. **Cost model** (when `openivm_adaptive_refresh = true`) decides whether IVM or full recompute is cheaper
 
-### Operator-Specific Rewrite Rules
+### Delta IR + Operator Dispatch
 
-`src/rules/incremental_rewrite_rule.cpp` dispatches based on operator type:
+Refresh planning builds a typed `DeltaViewModel` (a graph of `DeltaModelNode`, each carrying a kind,
+rule kind, maintenance mode, aux-state requirements, and lineage facts) from the optimized view plan —
+see `src/core/ivm_delta_model.cpp` and `src/core/ivm_view_classifier.cpp`. The `DeltaCompiler`
+(`src/delta/delta_compiler.cpp`) then walks the plan and lowers each node to a delta `DeltaPlanFragment`.
 
-| Operator | Rule Class | File |
+Dispatch is **single-sourced**: `NodeKindForOperator` (in `ivm_delta_model.cpp`) maps an operator type to
+a `DeltaModelNodeKind`, and `DispatchDeltaCompile` (`src/delta/operators/dispatch.cpp`) is the one switch
+that routes each kind to its `Compile*Delta` function. The model-driven path uses the node's kind; the
+copied-subtree path (join inclusion-exclusion terms, whose pointers aren't in the model) derives the kind
+from the operator type via the same `NodeKindForOperator`. Every returned fragment is checked for a valid
+multiplicity binding (`ValidateDeltaFragment`, a real exception in release builds).
+
+| Operator (`DeltaModelNodeKind`) | Compile function | File |
 |---|---|---|
-| Table Scan | `IncrementalScanRule` | `src/rules/scan.cpp` |
-| Inner/outer joins, cross product, any join | `IncrementalJoinRule` | `src/rules/join.cpp` |
-| DuckLake joins | N-term helper | `src/rules/ducklake_join.cpp` |
-| Projection | `IncrementalProjectionRule` | `src/rules/projection.cpp` |
-| Aggregate | `IncrementalAggregateRule` | `src/rules/aggregate.cpp` |
-| Filter | `IncrementalFilterRule` | `src/rules/filter.cpp` |
-| UNION ALL | `IncrementalUnionRule` | `src/rules/union.cpp` |
-| DISTINCT | `IncrementalDistinctRule` | `src/rules/distinct.cpp` |
-| Window | `IncrementalWindowRule` | `src/rules/window.cpp` |
-| ORDER BY / LIMIT / TOP_N | `IncrementalTopKRule` | `src/rules/topk.cpp` |
+| Table Scan (`SCAN`) | `CompileScanDelta` | `src/delta/operators/scan.cpp` |
+| Inner/outer joins, cross product, any join (`JOIN`/`SEMI_ANTI`) | `CompileJoinDelta` | `src/delta/operators/join.cpp` |
+| DuckLake / delim joins | `CompileDelimJoinDelta`, `Compile*` | `src/delta/operators/delim_join.cpp`, `ducklake_join.cpp` |
+| Projection (`PROJECT`) | `CompileProjectionDelta` | `src/delta/operators/` |
+| Aggregate (`AGGREGATE`) | `CompileAggregateDelta` | `src/delta/operators/` |
+| Filter (`FILTER`) | `CompileFilterDelta` | `src/delta/operators/` |
+| UNION ALL (`UNION`) | `CompileUnionDelta` | `src/delta/operators/` |
+| DISTINCT (`DISTINCT`) | `CompileDistinctDelta` | `src/delta/operators/` |
+| Window (`WINDOW`) | `CompileWindowDelta` | `src/delta/operators/` |
+| ORDER BY / LIMIT / TOP_N (`TOP_K`) | `CompileTopKDelta` | `src/delta/operators/` |
+| Constant leaf (`CONSTANT`) | `CompileConstantZeroDelta` (delta side) / `CompileStaticConstantLeaf` (copied base side) | `src/delta/operators/constant.cpp` |
 
-All rules inherit from `IncrementalRule` (`src/include/rules/rule.hpp`). Shared rule helpers live in `src/rules/helpers.cpp`.
+Shared delta-rule helpers live in `src/delta/delta_helpers.cpp` and the join helpers
+(`BuildMultiplicityProduct`, `CollectJoinLeaves`, …) in `src/delta/operators/join.cpp` /
+`src/include/delta/operators/`. The optimizer entry point is
+`src/rules/incremental_rewrite_rule.cpp` (detects the COMPUTEDELTA marker, builds the model, runs the
+compiler, adds the INSERT node).
 
 ### Join Delta Rule (Inclusion-Exclusion)
 
@@ -125,13 +140,16 @@ MIN/MAX and ARG_MIN/ARG_MAX usually force group-recompute unless insert-only fas
 - `src/core/parser.cpp` — parser extension for `CREATE MATERIALIZED VIEW`
 - `src/core/incremental_checker.cpp` — single-pass plan analysis and `RefreshType` classification metadata
 - `src/core/plan_rewrite.cpp` — CREATE-time logical-plan normalizations before LPTS and classification
-- `src/core/refresh_metadata.cpp` — system table queries (view definitions, delta tables, timestamps)
+- `src/core/refresh_metadata.cpp` — system table queries (view definitions, delta tables, timestamps); a `RefreshMetadata` instance memoizes definition-stable view columns
+- `src/core/ivm_delta_model.cpp` — `DeltaViewModel`/`DeltaModelNode` IR construction, `NodeKindForOperator`, lineage population (including the left-join-key lineage)
 - `src/core/sql_utils.cpp` — SQL string manipulation, file I/O, table name extraction
-- `src/rules/incremental_rewrite_rule.cpp` — rule dispatcher (routes to operator-specific rules)
+- `src/delta/delta_compiler.cpp` — `DeltaCompiler`: builds the refresh-time model and recursively lowers the plan to a delta plan
+- `src/delta/operators/dispatch.cpp` — single kind-based `DispatchDeltaCompile` + fragment-contract validation
+- `src/delta/operators/join.cpp` — join incrementalization (inclusion-exclusion; `BuildMultiplicityProduct`)
+- `src/delta/operators/ducklake_join.cpp` — DuckLake N-term telescoping join rule
+- `src/delta/delta_helpers.cpp` — shared delta-rule utilities (CreateDeltaGetNode, DuckLake delta nodes)
+- `src/rules/incremental_rewrite_rule.cpp` — optimizer entry point (COMPUTEDELTA marker → model → compile → INSERT)
 - `src/rules/refresh_insert_rule.cpp` — adds INSERT operators to inject deltas into views
-- `src/rules/join.cpp` — join incrementalization (inclusion-exclusion)
-- `src/rules/ducklake_join.cpp` — DuckLake N-term telescoping join rule
-- `src/rules/helpers.cpp` — shared rule utilities (CreateDeltaGetNode, DuckLake delta nodes)
 - `src/upsert/refresh.cpp` — PRAGMA refresh() handler, orchestrates delta computation
 - `src/upsert/refresh_compiler.cpp` — generates upsert SQL queries
 - `src/upsert/refresh_cost_model.cpp` — incremental refresh vs recompute cost estimation

--- a/src/core/ivm_delta_model.cpp
+++ b/src/core/ivm_delta_model.cpp
@@ -12,6 +12,62 @@
 
 namespace duckdb {
 
+// Map a logical operator to its delta-model node kind. This is the single source of truth for
+// operator-type -> kind, used both at model-build time and by the delta compiler's dispatch when no
+// model node exists (copied join subtrees, whose pointers are not in the model).
+DeltaModelNodeKind NodeKindForOperator(LogicalOperator &op) {
+	switch (op.type) {
+	case LogicalOperatorType::LOGICAL_GET:
+		return DeltaModelNodeKind::SCAN;
+	case LogicalOperatorType::LOGICAL_FILTER:
+		return DeltaModelNodeKind::FILTER;
+	case LogicalOperatorType::LOGICAL_PROJECTION:
+		return DeltaModelNodeKind::PROJECT;
+	case LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY:
+		return DeltaModelNodeKind::AGGREGATE;
+	case LogicalOperatorType::LOGICAL_WINDOW:
+		return DeltaModelNodeKind::WINDOW;
+	case LogicalOperatorType::LOGICAL_DISTINCT:
+		return DeltaModelNodeKind::DISTINCT;
+	case LogicalOperatorType::LOGICAL_UNION:
+		return DeltaModelNodeKind::UNION;
+	case LogicalOperatorType::LOGICAL_TOP_N:
+	case LogicalOperatorType::LOGICAL_LIMIT:
+	case LogicalOperatorType::LOGICAL_ORDER_BY:
+		return DeltaModelNodeKind::TOP_K;
+	case LogicalOperatorType::LOGICAL_UNNEST:
+		return DeltaModelNodeKind::UNNEST;
+	case LogicalOperatorType::LOGICAL_ASOF_JOIN:
+		return DeltaModelNodeKind::ASOF_JOIN;
+	case LogicalOperatorType::LOGICAL_POSITIONAL_JOIN:
+		return DeltaModelNodeKind::POSITIONAL_JOIN;
+	case LogicalOperatorType::LOGICAL_SAMPLE:
+		return DeltaModelNodeKind::SAMPLE;
+	case LogicalOperatorType::LOGICAL_DUMMY_SCAN:
+	case LogicalOperatorType::LOGICAL_EXPRESSION_GET:
+	case LogicalOperatorType::LOGICAL_CHUNK_GET:
+		return DeltaModelNodeKind::CONSTANT;
+	case LogicalOperatorType::LOGICAL_CTE_REF:
+	case LogicalOperatorType::LOGICAL_MATERIALIZED_CTE:
+		return DeltaModelNodeKind::CTE;
+	case LogicalOperatorType::LOGICAL_COMPARISON_JOIN:
+	case LogicalOperatorType::LOGICAL_ANY_JOIN:
+	case LogicalOperatorType::LOGICAL_DEPENDENT_JOIN:
+	case LogicalOperatorType::LOGICAL_DELIM_JOIN:
+	case LogicalOperatorType::LOGICAL_JOIN:
+	case LogicalOperatorType::LOGICAL_CROSS_PRODUCT: {
+		auto *join = dynamic_cast<LogicalJoin *>(&op);
+		if (join && (join->join_type == JoinType::SEMI || join->join_type == JoinType::ANTI ||
+		             join->join_type == JoinType::MARK)) {
+			return DeltaModelNodeKind::SEMI_ANTI;
+		}
+		return DeltaModelNodeKind::JOIN;
+	}
+	default:
+		return DeltaModelNodeKind::OTHER;
+	}
+}
+
 namespace {
 
 static bool ContainsStringCI(const vector<string> &values, const string &candidate) {
@@ -83,59 +139,6 @@ static vector<string> SourceTablesFromChildren(const DeltaViewModel &model, cons
 		}
 	}
 	return tables;
-}
-
-static DeltaModelNodeKind NodeKindForOperator(LogicalOperator &op) {
-	switch (op.type) {
-	case LogicalOperatorType::LOGICAL_GET:
-		return DeltaModelNodeKind::SCAN;
-	case LogicalOperatorType::LOGICAL_FILTER:
-		return DeltaModelNodeKind::FILTER;
-	case LogicalOperatorType::LOGICAL_PROJECTION:
-		return DeltaModelNodeKind::PROJECT;
-	case LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY:
-		return DeltaModelNodeKind::AGGREGATE;
-	case LogicalOperatorType::LOGICAL_WINDOW:
-		return DeltaModelNodeKind::WINDOW;
-	case LogicalOperatorType::LOGICAL_DISTINCT:
-		return DeltaModelNodeKind::DISTINCT;
-	case LogicalOperatorType::LOGICAL_UNION:
-		return DeltaModelNodeKind::UNION;
-	case LogicalOperatorType::LOGICAL_TOP_N:
-	case LogicalOperatorType::LOGICAL_LIMIT:
-	case LogicalOperatorType::LOGICAL_ORDER_BY:
-		return DeltaModelNodeKind::TOP_K;
-	case LogicalOperatorType::LOGICAL_UNNEST:
-		return DeltaModelNodeKind::UNNEST;
-	case LogicalOperatorType::LOGICAL_ASOF_JOIN:
-		return DeltaModelNodeKind::ASOF_JOIN;
-	case LogicalOperatorType::LOGICAL_POSITIONAL_JOIN:
-		return DeltaModelNodeKind::POSITIONAL_JOIN;
-	case LogicalOperatorType::LOGICAL_SAMPLE:
-		return DeltaModelNodeKind::SAMPLE;
-	case LogicalOperatorType::LOGICAL_DUMMY_SCAN:
-	case LogicalOperatorType::LOGICAL_EXPRESSION_GET:
-	case LogicalOperatorType::LOGICAL_CHUNK_GET:
-		return DeltaModelNodeKind::CONSTANT;
-	case LogicalOperatorType::LOGICAL_CTE_REF:
-	case LogicalOperatorType::LOGICAL_MATERIALIZED_CTE:
-		return DeltaModelNodeKind::CTE;
-	case LogicalOperatorType::LOGICAL_COMPARISON_JOIN:
-	case LogicalOperatorType::LOGICAL_ANY_JOIN:
-	case LogicalOperatorType::LOGICAL_DEPENDENT_JOIN:
-	case LogicalOperatorType::LOGICAL_DELIM_JOIN:
-	case LogicalOperatorType::LOGICAL_JOIN:
-	case LogicalOperatorType::LOGICAL_CROSS_PRODUCT: {
-		auto *join = dynamic_cast<LogicalJoin *>(&op);
-		if (join && (join->join_type == JoinType::SEMI || join->join_type == JoinType::ANTI ||
-		             join->join_type == JoinType::MARK)) {
-			return DeltaModelNodeKind::SEMI_ANTI;
-		}
-		return DeltaModelNodeKind::JOIN;
-	}
-	default:
-		return DeltaModelNodeKind::OTHER;
-	}
 }
 
 static DeltaRuleKind RuleKindForNode(DeltaModelNodeKind kind, LogicalOperator &op, const DeltaViewModel &model,
@@ -624,8 +627,18 @@ void PopulateDeltaViewModelLineage(DeltaViewModel &model, const CreateMVPlanFact
 	const auto &analysis = facts.analysis;
 	if (model.type == RefreshType::WINDOW_PARTITION) {
 		vector<RefreshMetadata::WindowPartitionLineageOp> direct_lineage_ops;
-		bool has_lineage = BuildWindowPartitionLineageOps(facts, model.window_partition_columns,
-		                                                  model.window_lineage_ops, &direct_lineage_ops);
+		bool unsafe_lookup = false;
+		bool has_lineage = BuildWindowPartitionLineageOps(
+		    facts, model.window_partition_columns, model.window_lineage_ops, &direct_lineage_ops, &unsafe_lookup);
+		// A cast-incomparable lookup join key (e.g. CAST(cik AS VARCHAR) = company_id) can't be reproduced as a
+		// safe affected-keys probe — fall back to a full current-diff recompute rather than risk under-counting.
+		if (unsafe_lookup) {
+			model.type = RefreshType::CURRENT_DIFF_RECOMPUTE;
+			model.window_lineage_ops.clear();
+			AddUnique(model.features, DeltaModelFeature::CURRENT_DIFF_RECOMPUTE);
+			ValidateDeltaViewModelInvariants(model);
+			return;
+		}
 		if (analysis.found_asof_join &&
 		    (!has_lineage || AsofWindowPartitionReadsRightSideDirectly(direct_lineage_ops, model) ||
 		     !WindowLineageCoversAllSources(model.window_lineage_ops, facts))) {
@@ -693,6 +706,9 @@ void PopulateDeltaViewModelLineage(DeltaViewModel &model, const CreateMVPlanFact
 			AddAffectedDomain(model, std::move(domain));
 		}
 	}
+	if (model.type == RefreshType::SIMPLE_PROJECTION && analysis.found_left_join && !analysis.found_full_outer) {
+		model.has_left_join_key_lineage = BuildLeftJoinKeyLineage(facts, model.left_join_key_lineage);
+	}
 	if (model.HasSemiAntiAux()) {
 		for (auto &col : model.semi_anti_aux.left_cols) {
 			DeltaLineageFact fact;
@@ -713,6 +729,9 @@ string BuildDeltaViewModelLineageJson(const DeltaViewModel &model) {
 	}
 	if (model.has_projection_lineage) {
 		entries.push_back(RefreshMetadata::ProjectionKeyLineageToJson(model.projection_lineage));
+	}
+	if (model.has_left_join_key_lineage) {
+		entries.push_back(RefreshMetadata::LeftJoinKeyLineageToJson(model.left_join_key_lineage));
 	}
 	return BuildRefreshLineageJson(entries);
 }

--- a/src/core/parser_plan_helpers.cpp
+++ b/src/core/parser_plan_helpers.cpp
@@ -1228,6 +1228,56 @@ bool BuildProjectionKeyLineage(const CreateMVPlanFacts &facts, const vector<stri
 	return false;
 }
 
+// First outer join in pre-order — matches ScanOuterJoins, which is the join RewriteLeftJoinKey traces
+// openivm_left_key from. Returns null if there is none.
+static LogicalComparisonJoin *FindFirstOuterJoin(LogicalOperator *node) {
+	if (!node) {
+		return nullptr;
+	}
+	if (node->type == LogicalOperatorType::LOGICAL_COMPARISON_JOIN) {
+		auto &join = node->Cast<LogicalComparisonJoin>();
+		if ((join.join_type == JoinType::LEFT || join.join_type == JoinType::RIGHT) && !join.conditions.empty()) {
+			return &join;
+		}
+	}
+	for (auto &child : node->children) {
+		if (auto *found = FindFirstOuterJoin(child.get())) {
+			return found;
+		}
+	}
+	return nullptr;
+}
+
+bool BuildLeftJoinKeyLineage(const CreateMVPlanFacts &facts, RefreshMetadata::ProjectionKeyLineage &out) {
+	auto *outer = FindFirstOuterJoin(facts.root);
+	if (!outer) {
+		return false;
+	}
+	// Preserved side carries the surviving key (LEFT keeps left, RIGHT keeps right).
+	auto &condition = outer->conditions[0];
+	auto &preserved = outer->join_type == JoinType::RIGHT ? condition.right : condition.left;
+	auto *bcr = GetColumnRefThroughCasts(preserved.get());
+	if (!bcr) {
+		return false; // derived / non-column key — fall back to full recompute
+	}
+	OccurrenceColumnRef ref;
+	if (!ResolveBindingToOccurrenceRef(bcr->binding, facts, ref)) {
+		return false; // could not pin the key to a single source binding
+	}
+	RefreshMetadata::ProjectionKeyLineage lineage;
+	lineage.output_col = string(openivm::LEFT_KEY_COL);
+	lineage.key_source = ref.table;
+	lineage.key_occurrence = ref.occurrence;
+	lineage.key_col = ref.column;
+	RefreshMetadata::ProjectionKeyLineageArm arm;
+	arm.source = ref.table;
+	arm.occurrence = ref.occurrence;
+	arm.source_col = ref.column;
+	lineage.arms.push_back(std::move(arm));
+	out = std::move(lineage);
+	return true;
+}
+
 struct WindowLineageOp {
 	string kind;
 	string output_col;
@@ -1332,7 +1382,7 @@ static void CollectInnerJoinEdgesOccurrence(LogicalOperator *op, const CreateMVP
 }
 
 static void CollectWindowLookupEdges(LogicalOperator *op, const CreateMVPlanFacts &facts,
-                                     vector<WindowLookupEdge> &edges) {
+                                     vector<WindowLookupEdge> &edges, bool &has_unsafe_lookup_key) {
 	if (op->type == LogicalOperatorType::LOGICAL_COMPARISON_JOIN ||
 	    op->type == LogicalOperatorType::LOGICAL_ASOF_JOIN) {
 		auto &join = op->Cast<LogicalComparisonJoin>();
@@ -1347,6 +1397,15 @@ static void CollectWindowLookupEdges(LogicalOperator *op, const CreateMVPlanFact
 			auto *right = GetColumnRefThroughCasts(cond.right.get());
 			if (!left || !right) {
 				continue;
+			}
+			// The affected-keys lookup reproduces this equi-join as a raw `col IN (lookup_col)` probe over the
+			// base columns. If the join wrapped the keys in a cast to make incomparable types match (e.g.
+			// CAST(cik AS VARCHAR) = company_id, BIGINT vs VARCHAR), that probe would either fail to bind or
+			// silently under-count, so mark the lineage unsafe and let the view fall back to a full recompute.
+			// Differing-but-numeric types (e.g. INTEGER vs BIGINT) bind and compare by value, so they are safe.
+			if (left->return_type != right->return_type &&
+			    !(left->return_type.IsNumeric() && right->return_type.IsNumeric())) {
+				has_unsafe_lookup_key = true;
 			}
 			OccurrenceColumnRef lref, rref;
 			if (!ResolveBindingToOccurrenceRef(left->binding, facts, lref) ||
@@ -1372,7 +1431,7 @@ static void CollectWindowLookupEdges(LogicalOperator *op, const CreateMVPlanFact
 		}
 	}
 	for (auto &child : op->children) {
-		CollectWindowLookupEdges(child.get(), facts, edges);
+		CollectWindowLookupEdges(child.get(), facts, edges, has_unsafe_lookup_key);
 	}
 }
 
@@ -1467,10 +1526,14 @@ static RefreshMetadata::WindowPartitionLineageOp ToMetadataWindowLineageOp(const
 
 bool BuildWindowPartitionLineageOps(const CreateMVPlanFacts &facts, const vector<string> &partition_columns,
                                     vector<RefreshMetadata::WindowPartitionLineageOp> &out,
-                                    vector<RefreshMetadata::WindowPartitionLineageOp> *direct_out) {
+                                    vector<RefreshMetadata::WindowPartitionLineageOp> *direct_out,
+                                    bool *out_unsafe_lookup) {
 	out.clear();
 	if (direct_out) {
 		direct_out->clear();
+	}
+	if (out_unsafe_lookup) {
+		*out_unsafe_lookup = false;
 	}
 	if (!facts.root || partition_columns.empty()) {
 		return false;
@@ -1494,7 +1557,11 @@ bool BuildWindowPartitionLineageOps(const CreateMVPlanFacts &facts, const vector
 	vector<pair<OccurrenceColumnRef, OccurrenceColumnRef>> edges;
 	CollectInnerJoinEdgesOccurrence(plan, facts, edges);
 	vector<WindowLookupEdge> lookup_edges;
-	CollectWindowLookupEdges(plan, facts, lookup_edges);
+	bool unsafe_lookup_key = false;
+	CollectWindowLookupEdges(plan, facts, lookup_edges, unsafe_lookup_key);
+	if (out_unsafe_lookup) {
+		*out_unsafe_lookup = unsafe_lookup_key;
+	}
 
 	vector<WindowLineageOp> partition_ops;
 	for (auto &op : direct_ops) {

--- a/src/core/refresh_metadata.cpp
+++ b/src/core/refresh_metadata.cpp
@@ -16,61 +16,66 @@ bool RefreshMetadata::IsBaseTable(const string &table_name) {
 	return !result->HasError() && result->RowCount() == 0;
 }
 
-string RefreshMetadata::GetViewQuery(const string &view_name) {
-	auto result = con.Query("SELECT sql_string FROM " + string(openivm::VIEWS_TABLE) + " WHERE view_name = '" +
-	                        SqlUtils::EscapeValue(view_name) + "'");
-	if (result->HasError() || result->RowCount() == 0) {
-		return "";
+const RefreshMetadata::ViewMetaRow &RefreshMetadata::GetViewMeta(const string &view_name) {
+	auto cached = view_meta_cache.find(view_name);
+	if (cached != view_meta_cache.end()) {
+		return cached->second;
 	}
-	return result->GetValue(0, 0).ToString();
+	ViewMetaRow row;
+	auto result =
+	    con.Query("SELECT sql_string, type, has_minmax, has_left_join, has_full_outer, full_outer_join_cols FROM " +
+	              string(openivm::VIEWS_TABLE) + " WHERE view_name = '" + SqlUtils::EscapeValue(view_name) + "'");
+	if (!result->HasError() && result->RowCount() > 0) {
+		row.found = true;
+		if (!result->GetValue(0, 0).IsNull()) {
+			row.sql_string = result->GetValue(0, 0).ToString();
+		}
+		if (!result->GetValue(1, 0).IsNull()) {
+			row.type = static_cast<RefreshType>(result->GetValue(1, 0).GetValue<int8_t>());
+		}
+		row.has_minmax = !result->GetValue(2, 0).IsNull() && result->GetValue(2, 0).GetValue<bool>();
+		row.has_left_join = !result->GetValue(3, 0).IsNull() && result->GetValue(3, 0).GetValue<bool>();
+		row.has_full_outer = !result->GetValue(4, 0).IsNull() && result->GetValue(4, 0).GetValue<bool>();
+		if (!result->GetValue(5, 0).IsNull()) {
+			row.full_outer_join_cols = result->GetValue(5, 0).ToString();
+		}
+	}
+	return view_meta_cache.emplace(view_name, std::move(row)).first->second;
+}
+
+string RefreshMetadata::GetViewQuery(const string &view_name) {
+	return GetViewMeta(view_name).sql_string;
 }
 
 RefreshType RefreshMetadata::GetViewType(const string &view_name) {
-	auto result = con.Query("SELECT type FROM " + string(openivm::VIEWS_TABLE) + " WHERE view_name = '" +
-	                        SqlUtils::EscapeValue(view_name) + "'");
-	if (result->HasError() || result->RowCount() == 0) {
+	auto &meta = GetViewMeta(view_name);
+	if (!meta.found) {
 		throw ParserException("Materialized view '%s' does not exist in IVM metadata.", view_name);
 	}
-	return static_cast<RefreshType>(result->GetValue(0, 0).GetValue<int8_t>());
+	return meta.type;
 }
 
 bool RefreshMetadata::HasMinMax(const string &view_name) {
-	auto result = con.Query("SELECT has_minmax FROM " + string(openivm::VIEWS_TABLE) + " WHERE view_name = '" +
-	                        SqlUtils::EscapeValue(view_name) + "'");
-	if (result->HasError() || result->RowCount() == 0 || result->GetValue(0, 0).IsNull()) {
-		return false;
-	}
-	return result->GetValue(0, 0).GetValue<bool>();
+	return GetViewMeta(view_name).has_minmax;
 }
 
 bool RefreshMetadata::HasLeftJoin(const string &view_name) {
-	auto result = con.Query("SELECT has_left_join FROM " + string(openivm::VIEWS_TABLE) + " WHERE view_name = '" +
-	                        SqlUtils::EscapeValue(view_name) + "'");
-	if (result->HasError() || result->RowCount() == 0 || result->GetValue(0, 0).IsNull()) {
-		return false;
-	}
-	return result->GetValue(0, 0).GetValue<bool>();
+	return GetViewMeta(view_name).has_left_join;
 }
 
 bool RefreshMetadata::HasFullOuter(const string &view_name) {
-	auto result = con.Query("SELECT has_full_outer FROM " + string(openivm::VIEWS_TABLE) + " WHERE view_name = '" +
-	                        SqlUtils::EscapeValue(view_name) + "'");
-	if (result->HasError() || result->RowCount() == 0 || result->GetValue(0, 0).IsNull()) {
-		return false;
-	}
-	return result->GetValue(0, 0).GetValue<bool>();
+	return GetViewMeta(view_name).has_full_outer;
 }
 
 string RefreshMetadata::GetFullOuterJoinCols(const string &view_name) {
-	auto result = con.Query("SELECT full_outer_join_cols FROM " + string(openivm::VIEWS_TABLE) +
-	                        " WHERE view_name = '" + SqlUtils::EscapeValue(view_name) + "'");
-	if (result->HasError() || result->RowCount() == 0 || result->GetValue(0, 0).IsNull()) {
-		return "";
-	}
-	return result->GetValue(0, 0).ToString();
+	return GetViewMeta(view_name).full_outer_join_cols;
 }
 
 vector<string> RefreshMetadata::GetDeltaTables(const string &view_name) {
+	auto cached = delta_tables_cache.find(view_name);
+	if (cached != delta_tables_cache.end()) {
+		return cached->second;
+	}
 	auto result = con.Query("SELECT table_name FROM " + string(openivm::DELTA_TABLES_TABLE) + " WHERE view_name = '" +
 	                        SqlUtils::EscapeValue(view_name) + "'");
 	vector<string> tables;
@@ -79,6 +84,7 @@ vector<string> RefreshMetadata::GetDeltaTables(const string &view_name) {
 			tables.push_back(result->GetValue(0, i).ToString());
 		}
 	}
+	delta_tables_cache.emplace(view_name, tables);
 	return tables;
 }
 
@@ -251,39 +257,47 @@ vector<string> RefreshMetadata::GetDownstreamViews(const string &view_name) {
 }
 
 vector<string> RefreshMetadata::GetGroupColumns(const string &view_name) {
+	auto cached = group_columns_cache.find(view_name);
+	if (cached != group_columns_cache.end()) {
+		return cached->second;
+	}
 	auto result = con.Query("SELECT group_columns FROM " + string(openivm::VIEWS_TABLE) + " WHERE view_name = '" +
 	                        SqlUtils::EscapeValue(view_name) + "'");
 	vector<string> cols;
-	if (result->HasError() || result->RowCount() == 0 || result->GetValue(0, 0).IsNull()) {
-		return cols;
-	}
-	string raw = result->GetValue(0, 0).ToString();
-	// Split comma-separated column names
-	std::istringstream ss(raw);
-	string token;
-	while (std::getline(ss, token, ',')) {
-		if (!token.empty()) {
-			cols.push_back(token);
+	if (!result->HasError() && result->RowCount() > 0 && !result->GetValue(0, 0).IsNull()) {
+		string raw = result->GetValue(0, 0).ToString();
+		// Split comma-separated column names
+		std::istringstream ss(raw);
+		string token;
+		while (std::getline(ss, token, ',')) {
+			if (!token.empty()) {
+				cols.push_back(token);
+			}
 		}
 	}
+	group_columns_cache.emplace(view_name, cols);
 	return cols;
 }
 
 vector<string> RefreshMetadata::GetAggregateTypes(const string &view_name) {
+	auto cached = aggregate_types_cache.find(view_name);
+	if (cached != aggregate_types_cache.end()) {
+		return cached->second;
+	}
 	auto result = con.Query("SELECT aggregate_types FROM " + string(openivm::VIEWS_TABLE) + " WHERE view_name = '" +
 	                        SqlUtils::EscapeValue(view_name) + "'");
 	vector<string> types;
-	if (result->HasError() || result->RowCount() == 0 || result->GetValue(0, 0).IsNull()) {
-		return types;
-	}
-	string raw = result->GetValue(0, 0).ToString();
-	std::istringstream ss(raw);
-	string token;
-	while (std::getline(ss, token, ',')) {
-		if (!token.empty()) {
-			types.push_back(token);
+	if (!result->HasError() && result->RowCount() > 0 && !result->GetValue(0, 0).IsNull()) {
+		string raw = result->GetValue(0, 0).ToString();
+		std::istringstream ss(raw);
+		string token;
+		while (std::getline(ss, token, ',')) {
+			if (!token.empty()) {
+				types.push_back(token);
+			}
 		}
 	}
+	aggregate_types_cache.emplace(view_name, types);
 	return types;
 }
 
@@ -848,11 +862,7 @@ string RefreshMetadata::WindowPartitionLineageToJson(const vector<WindowPartitio
 	return json;
 }
 
-bool RefreshMetadata::GetProjectionKeyLineage(const string &view_name, ProjectionKeyLineage &out) {
-	string json;
-	if (!ReadRefreshLineageEntry(con, view_name, "projection_key", json)) {
-		return false;
-	}
+static bool ParseProjectionKeyLineageJson(const string &json, RefreshMetadata::ProjectionKeyLineage &out) {
 	if (!ExtractJsonString(json, "out", out.output_col) || !ExtractJsonString(json, "key_source", out.key_source) ||
 	    !ParseJsonIndex(json, "key_occ", out.key_occurrence) || !ExtractJsonString(json, "key_col", out.key_col)) {
 		return false;
@@ -860,7 +870,7 @@ bool RefreshMetadata::GetProjectionKeyLineage(const string &view_name, Projectio
 	out.arms.clear();
 	auto objects = ExtractJsonObjectsFromArray(json, "arms");
 	for (auto &object : objects) {
-		ProjectionKeyLineageArm arm;
+		RefreshMetadata::ProjectionKeyLineageArm arm;
 		if (!ExtractJsonString(object, "source", arm.source) || !ParseJsonIndex(object, "occ", arm.occurrence) ||
 		    !ExtractJsonString(object, "source_col", arm.source_col)) {
 			continue;
@@ -872,7 +882,7 @@ bool RefreshMetadata::GetProjectionKeyLineage(const string &view_name, Projectio
 			if (fields.size() != 4) {
 				continue;
 			}
-			ProjectionKeyLineageStep step;
+			RefreshMetadata::ProjectionKeyLineageStep step;
 			step.table = fields[0];
 			try {
 				step.occurrence = static_cast<idx_t>(std::stoull(fields[1]));
@@ -888,8 +898,25 @@ bool RefreshMetadata::GetProjectionKeyLineage(const string &view_name, Projectio
 	return !out.arms.empty();
 }
 
-string RefreshMetadata::ProjectionKeyLineageToJson(const ProjectionKeyLineage &lineage) {
-	string json = "{\"k\":\"projection_key\",\"out\":" + SqlUtils::JsonQuote(lineage.output_col) +
+bool RefreshMetadata::GetProjectionKeyLineage(const string &view_name, ProjectionKeyLineage &out) {
+	string json;
+	if (!ReadRefreshLineageEntry(con, view_name, "projection_key", json)) {
+		return false;
+	}
+	return ParseProjectionKeyLineageJson(json, out);
+}
+
+bool RefreshMetadata::GetLeftJoinKeyLineage(const string &view_name, ProjectionKeyLineage &out) {
+	string json;
+	if (!ReadRefreshLineageEntry(con, view_name, "left_join_key", json)) {
+		return false;
+	}
+	return ParseProjectionKeyLineageJson(json, out);
+}
+
+static string ProjectionKeyLineageToJsonWithKind(const RefreshMetadata::ProjectionKeyLineage &lineage,
+                                                 const char *kind) {
+	string json = "{\"k\":" + SqlUtils::JsonQuote(kind) + ",\"out\":" + SqlUtils::JsonQuote(lineage.output_col) +
 	              ",\"key_source\":" + SqlUtils::JsonQuote(lineage.key_source) +
 	              ",\"key_occ\":" + SqlUtils::JsonQuote(to_string(lineage.key_occurrence)) +
 	              ",\"key_col\":" + SqlUtils::JsonQuote(lineage.key_col) + ",\"arms\":[";
@@ -913,6 +940,14 @@ string RefreshMetadata::ProjectionKeyLineageToJson(const ProjectionKeyLineage &l
 	}
 	json += "]}";
 	return json;
+}
+
+string RefreshMetadata::ProjectionKeyLineageToJson(const ProjectionKeyLineage &lineage) {
+	return ProjectionKeyLineageToJsonWithKind(lineage, "projection_key");
+}
+
+string RefreshMetadata::LeftJoinKeyLineageToJson(const ProjectionKeyLineage &lineage) {
+	return ProjectionKeyLineageToJsonWithKind(lineage, "left_join_key");
 }
 
 bool RefreshMetadata::GetFilteredGroupCountAuxMeta(const string &view_name, FilteredGroupCountAuxMeta &out) {

--- a/src/core/sql_utils.cpp
+++ b/src/core/sql_utils.cpp
@@ -664,6 +664,31 @@ string SqlUtils::DuckLakeTableFunction(const string &function_name, const string
 	       "', " + to_string(last_snapshot_id) + ", " + to_string(current_snapshot_id) + ")";
 }
 
+string SqlUtils::StripTrackedTablePrefix(const string &name, bool strip_delta) {
+	static const string data_prefix(openivm::DATA_TABLE_PREFIX);
+	static const string delta_prefix(openivm::DELTA_PREFIX);
+	string last = LastIdentifierPart(name);
+	if (last.size() > data_prefix.size() && last.rfind(data_prefix, 0) == 0) {
+		return last.substr(data_prefix.size());
+	}
+	if (strip_delta && last.size() > delta_prefix.size() && last.rfind(delta_prefix, 0) == 0) {
+		return last.substr(delta_prefix.size());
+	}
+	return last;
+}
+
+string SqlUtils::BuildDuckLakeChangeFeed(const string &catalog, const string &schema, const string &table,
+                                         int64_t last_snapshot_id, int64_t current_snapshot_id,
+                                         const string &select_list) {
+	string insertions = "SELECT " + select_list + " FROM " +
+	                    DuckLakeTableFunction("ducklake_table_insertions", catalog, schema, table, last_snapshot_id,
+	                                          current_snapshot_id);
+	string deletions = "SELECT " + select_list + " FROM " +
+	                   DuckLakeTableFunction("ducklake_table_deletions", catalog, schema, table, last_snapshot_id,
+	                                         current_snapshot_id);
+	return "(" + insertions + "\nUNION ALL\n" + deletions + ")";
+}
+
 bool SqlUtils::IsDelta(const string &name) {
 	static const string prefix(openivm::DELTA_PREFIX);
 	return name.size() >= prefix.size() && name.rfind(prefix, 0) == 0;

--- a/src/delta/operators/delim_join.cpp
+++ b/src/delta/operators/delim_join.cpp
@@ -3,6 +3,7 @@
 #include "core/openivm_constants.hpp"
 #include "core/openivm_debug.hpp"
 #include "delta/operators/join.hpp"
+#include "delta/operators/join_key_probe.hpp"
 #include "upsert/refresh_index_regen.hpp"
 #include "duckdb/function/function_binder.hpp"
 #include "duckdb/optimizer/column_binding_replacer.hpp"
@@ -94,29 +95,6 @@ static bool IsSafeSemiAntiDelimJoin(LogicalOperator &op) {
 	return !join.duplicate_eliminated_columns.empty();
 }
 
-static void UpdateProjectionMapForLeaf(unique_ptr<LogicalOperator> &term, const BaseLeafInfo &leaf) {
-	if (leaf.path.empty()) {
-		return;
-	}
-	size_t child_side = leaf.path.back();
-	unique_ptr<LogicalOperator> *parent = &term;
-	for (size_t s = 0; s + 1 < leaf.path.size(); s++) {
-		parent = &((*parent)->children[leaf.path[s]]);
-	}
-	if (!IsJoinNode((*parent)->type)) {
-		return;
-	}
-	auto *join = dynamic_cast<LogicalComparisonJoin *>((*parent).get());
-	if (!join) {
-		return;
-	}
-	auto &proj_map = (child_side == 0) ? join->left_projection_map : join->right_projection_map;
-	if (!proj_map.empty()) {
-		idx_t mul_idx = leaf.node->GetColumnBindings().size();
-		proj_map.push_back(mul_idx);
-	}
-}
-
 static unique_ptr<LogicalOperator> BuildDelimKeySource(ClientContext &context, LogicalComparisonJoin &delim_join,
                                                        LogicalDelimGet &delim_get, bool allow_ordinal_fallback) {
 	if (delim_join.children.size() != 2) {
@@ -174,10 +152,6 @@ static unique_ptr<LogicalOperator> BuildDelimKeySource(ClientContext &context, L
 }
 
 static void RebindAllExpressions(LogicalOperator &op, ColumnBindingReplacer &replacer);
-
-static uint64_t BindingKey(const ColumnBinding &binding) {
-	return (uint64_t)binding.table_index ^ ((uint64_t)binding.column_index * 0x9e3779b97f4a7c15ULL);
-}
 
 static void AddColumnBindingReplacements(const vector<ColumnBinding> &old_bindings,
                                          const vector<ColumnBinding> &new_bindings,
@@ -333,35 +307,8 @@ static void RebindAllExpressions(LogicalOperator &op, ColumnBindingReplacer &rep
 
 static void CollectMulBindings(const vector<ColumnBinding> &mul_bindings, unordered_set<uint64_t> &mul_set) {
 	for (auto &mb : mul_bindings) {
-		mul_set.insert(BindingKey(mb));
+		mul_set.insert(DeltaJoinBindingKey(mb));
 	}
-}
-
-static unique_ptr<Expression> BuildMultiplicityProduct(Binder &binder, const LogicalType &mul_type,
-                                                       const vector<ColumnBinding> &mul_bindings) {
-	FunctionBinder fbinder(binder);
-	unique_ptr<Expression> product = make_uniq<BoundColumnRefExpression>(mul_type, mul_bindings[0]);
-	for (size_t i = 1; i < mul_bindings.size(); i++) {
-		vector<unique_ptr<Expression>> args;
-		args.push_back(std::move(product));
-		args.push_back(make_uniq<BoundColumnRefExpression>(mul_type, mul_bindings[i]));
-		ErrorData err;
-		product = fbinder.BindScalarFunction(DEFAULT_SCHEMA, "*", std::move(args), err, true);
-		if (!product) {
-			throw InternalException("DeltaDelimJoin: failed to bind multiplicity product: %s", err.RawMessage());
-		}
-	}
-	if (mul_bindings.size() % 2 == 0) {
-		vector<unique_ptr<Expression>> args;
-		args.push_back(make_uniq<BoundConstantExpression>(Value::INTEGER(-1)));
-		args.push_back(std::move(product));
-		ErrorData err;
-		product = fbinder.BindScalarFunction(DEFAULT_SCHEMA, "*", std::move(args), err, true);
-		if (!product) {
-			throw InternalException("DeltaDelimJoin: failed to bind multiplicity sign: %s", err.RawMessage());
-		}
-	}
-	return product;
 }
 
 static unique_ptr<LogicalOperator> AssembleUnionAll(vector<unique_ptr<LogicalOperator>> &terms,
@@ -500,7 +447,7 @@ DeltaPlanFragment CompileDelimJoinDelta(DeltaOperatorInput input) {
 			AddLeafBindingReplacements(leaf_bindings, delta_bindings, output_replacements, delta_i.mul_binding);
 			mul_bindings.push_back(delta_i.mul_binding);
 			leaf_ref = std::move(delta_i.node);
-			UpdateProjectionMapForLeaf(term, leaves[i]);
+			UpdateParentProjectionMap(term, leaves[i].path, leaves[i].node, /*include_delim_parents=*/true);
 		}
 
 		vector<ReplacementBinding> delim_replacements;
@@ -514,7 +461,7 @@ DeltaPlanFragment CompileDelimJoinDelta(DeltaOperatorInput input) {
 		for (idx_t output_idx = 0; output_idx < original_bindings.size(); output_idx++) {
 			auto mapped_binding =
 			    MapTermBinding(original_bindings[output_idx], renumbered.idx_map, output_replacements);
-			if (mul_set.count(BindingKey(mapped_binding))) {
+			if (mul_set.count(DeltaJoinBindingKey(mapped_binding))) {
 				throw InternalException("DeltaDelimJoin: original output remapped to multiplicity binding");
 			}
 			auto output_binding = FindOutputBinding(term_bindings, mapped_binding);

--- a/src/delta/operators/dispatch.cpp
+++ b/src/delta/operators/dispatch.cpp
@@ -31,6 +31,70 @@ static bool IsDelimJoinShape(LogicalOperatorType type) {
 	return type == LogicalOperatorType::LOGICAL_DELIM_JOIN || type == LogicalOperatorType::LOGICAL_DEPENDENT_JOIN;
 }
 
+// Every delta fragment must expose exactly one multiplicity column as a real output binding — that is the
+// compositional contract the parent operator relies on. Enforce it at every dispatch boundary (a real
+// exception, not a D_ASSERT, so the invariant holds in release builds too).
+static void ValidateDeltaFragment(const DeltaPlanFragment &fragment, LogicalOperatorType op_type,
+                                  DeltaModelNodeKind kind) {
+	if (!fragment.op) {
+		throw InternalException("Delta compile produced a null fragment for %s (kind %s)",
+		                        LogicalOperatorToString(op_type), DeltaModelNodeKindName(kind));
+	}
+	if (fragment.mul_binding.table_index == DConstants::INVALID_INDEX) {
+		throw InternalException("Delta fragment for %s (kind %s) has no multiplicity binding",
+		                        LogicalOperatorToString(op_type), DeltaModelNodeKindName(kind));
+	}
+}
+
+// Single source of truth for delta compilation. Both the model-driven path and the copied-subtree path
+// route through here keyed on DeltaModelNodeKind, so there is exactly one operator->compiler table to keep
+// in sync. The only state-dependent case is a constant leaf: inside a copied "current-base" join term it
+// must emit its static content (multiplicity +1), everywhere else it emits an empty (zero) delta.
+static DeltaPlanFragment DispatchDeltaCompile(const DeltaOperatorInput &input, DeltaModelNodeKind kind) {
+	auto op_type = input.plan->type;
+	DeltaPlanFragment fragment = [&]() -> DeltaPlanFragment {
+		switch (kind) {
+		case DeltaModelNodeKind::SCAN:
+			return CompileScanDelta(input);
+		case DeltaModelNodeKind::FILTER:
+			return CompileFilterDelta(input);
+		case DeltaModelNodeKind::PROJECT:
+			return CompileProjectionDelta(input);
+		case DeltaModelNodeKind::AGGREGATE:
+			return CompileAggregateDelta(input);
+		case DeltaModelNodeKind::JOIN:
+		case DeltaModelNodeKind::SEMI_ANTI:
+			return IsDelimJoinShape(op_type) ? CompileDelimJoinDelta(input) : CompileJoinDelta(input);
+		case DeltaModelNodeKind::UNION:
+			return CompileUnionDelta(input);
+		case DeltaModelNodeKind::DISTINCT:
+			return CompileDistinctDelta(input);
+		case DeltaModelNodeKind::WINDOW:
+			return CompileWindowDelta(input);
+		case DeltaModelNodeKind::TOP_K:
+			return CompileTopKDelta(input);
+		case DeltaModelNodeKind::CTE:
+			return CompileCteDelta(input);
+		case DeltaModelNodeKind::UNNEST:
+			return CompileUnnestDelta(input);
+		case DeltaModelNodeKind::CONSTANT:
+			return input.copied_subtree ? CompileStaticConstantLeaf(input) : CompileConstantZeroDelta(input);
+		case DeltaModelNodeKind::ASOF_JOIN:
+			return CompileAsofJoinDelta(input);
+		case DeltaModelNodeKind::POSITIONAL_JOIN:
+			return CompilePositionalJoinDelta(input);
+		case DeltaModelNodeKind::SAMPLE:
+			return CompileSampleDelta(input);
+		case DeltaModelNodeKind::OTHER:
+		default:
+			throw NotImplementedException("Delta compiler: operator %s (kind %s) not supported",
+			                              LogicalOperatorToString(op_type), DeltaModelNodeKindName(kind));
+		}
+	}();
+	ValidateDeltaFragment(fragment, op_type, kind);
+	return fragment;
+}
+
 } // namespace
 
 const char *DeltaOperatorStrategyName(DeltaOperatorStrategy strategy) {
@@ -95,98 +159,16 @@ void LogDeltaOperatorStrategy(const DeltaOperatorInput &input, DeltaOperatorStra
 
 DeltaPlanFragment CompileDeltaOperatorWithModel(const DeltaOperatorInput &input, const DeltaModelNode &node) {
 	ValidateCompileNode(node, input.plan.get());
-	auto node_input = input.WithNode(node);
-	switch (node.kind) {
-	case DeltaModelNodeKind::SCAN:
-		return CompileScanDelta(node_input);
-	case DeltaModelNodeKind::FILTER:
-		return CompileFilterDelta(node_input);
-	case DeltaModelNodeKind::PROJECT:
-		return CompileProjectionDelta(node_input);
-	case DeltaModelNodeKind::AGGREGATE:
-		return CompileAggregateDelta(node_input);
-	case DeltaModelNodeKind::JOIN:
-	case DeltaModelNodeKind::SEMI_ANTI:
-		return IsDelimJoinShape(node_input.plan->type) ? CompileDelimJoinDelta(node_input)
-		                                               : CompileJoinDelta(node_input);
-	case DeltaModelNodeKind::UNION:
-		return CompileUnionDelta(node_input);
-	case DeltaModelNodeKind::DISTINCT:
-		return CompileDistinctDelta(node_input);
-	case DeltaModelNodeKind::WINDOW:
-		return CompileWindowDelta(node_input);
-	case DeltaModelNodeKind::TOP_K:
-		return CompileTopKDelta(node_input);
-	case DeltaModelNodeKind::CTE:
-		return CompileCteDelta(node_input);
-	case DeltaModelNodeKind::UNNEST:
-		return CompileUnnestDelta(node_input);
-	case DeltaModelNodeKind::CONSTANT:
-		return CompileConstantZeroDelta(node_input);
-	case DeltaModelNodeKind::ASOF_JOIN:
-		return CompileAsofJoinDelta(node_input);
-	case DeltaModelNodeKind::POSITIONAL_JOIN:
-		return CompilePositionalJoinDelta(node_input);
-	case DeltaModelNodeKind::SAMPLE:
-		return CompileSampleDelta(node_input);
-	case DeltaModelNodeKind::OTHER:
-		throw NotImplementedException("Delta model node kind %s not supported", DeltaModelNodeKindName(node.kind));
-	default:
-		throw NotImplementedException("Delta model node kind %s not supported", DeltaModelNodeKindName(node.kind));
-	}
+	return DispatchDeltaCompile(input.WithNode(node), node.kind);
 }
 
 DeltaPlanFragment CompileCopiedDeltaSubtree(DeltaOperatorInput input) {
 	OPENIVM_DEBUG_PRINT("[Copied Delta Subtree] Visiting node: %s\n",
 	                    LogicalOperatorToString(input.plan->type).c_str());
 	OPENIVM_DEBUG_PRINT("[Copied Delta Subtree] Node detail: %s\n", input.plan->ToString().c_str());
-
-	switch (input.plan->type) {
-	case LogicalOperatorType::LOGICAL_GET:
-		return CompileScanDelta(input);
-	case LogicalOperatorType::LOGICAL_COMPARISON_JOIN:
-	case LogicalOperatorType::LOGICAL_JOIN:
-	case LogicalOperatorType::LOGICAL_CROSS_PRODUCT:
-	case LogicalOperatorType::LOGICAL_ANY_JOIN:
-		return CompileJoinDelta(input);
-	case LogicalOperatorType::LOGICAL_DELIM_JOIN:
-	case LogicalOperatorType::LOGICAL_DEPENDENT_JOIN:
-		return CompileDelimJoinDelta(input);
-	case LogicalOperatorType::LOGICAL_PROJECTION:
-		return CompileProjectionDelta(input);
-	case LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY:
-		return CompileAggregateDelta(input);
-	case LogicalOperatorType::LOGICAL_FILTER:
-		return CompileFilterDelta(input);
-	case LogicalOperatorType::LOGICAL_UNION:
-		return CompileUnionDelta(input);
-	case LogicalOperatorType::LOGICAL_DISTINCT:
-		return CompileDistinctDelta(input);
-	case LogicalOperatorType::LOGICAL_WINDOW:
-		return CompileWindowDelta(input);
-	case LogicalOperatorType::LOGICAL_TOP_N:
-	case LogicalOperatorType::LOGICAL_LIMIT:
-	case LogicalOperatorType::LOGICAL_ORDER_BY:
-		return CompileTopKDelta(input);
-	case LogicalOperatorType::LOGICAL_MATERIALIZED_CTE:
-	case LogicalOperatorType::LOGICAL_CTE_REF:
-		return CompileCteDelta(input);
-	case LogicalOperatorType::LOGICAL_UNNEST:
-		return CompileUnnestDelta(input);
-	case LogicalOperatorType::LOGICAL_ASOF_JOIN:
-		return CompileAsofJoinDelta(input);
-	case LogicalOperatorType::LOGICAL_POSITIONAL_JOIN:
-		return CompilePositionalJoinDelta(input);
-	case LogicalOperatorType::LOGICAL_SAMPLE:
-		return CompileSampleDelta(input);
-	case LogicalOperatorType::LOGICAL_CHUNK_GET:
-	case LogicalOperatorType::LOGICAL_DUMMY_SCAN:
-	case LogicalOperatorType::LOGICAL_EXPRESSION_GET:
-		return CompileStaticConstantLeaf(input);
-	default:
-		throw NotImplementedException("Copied subtree operator type %s not supported",
-		                              LogicalOperatorToString(input.plan->type));
-	}
+	// Copied subtrees (join inclusion-exclusion terms) carry fresh operator pointers that are not in the
+	// model, so derive the kind from the operator type — the same mapping the model itself was built from.
+	return DispatchDeltaCompile(input, NodeKindForOperator(*input.plan));
 }
 
 DeltaPlanFragment CompileNonModelLeaf(DeltaOperatorInput input) {

--- a/src/delta/operators/ducklake_join.cpp
+++ b/src/delta/operators/ducklake_join.cpp
@@ -272,7 +272,7 @@ vector<unique_ptr<LogicalOperator>> BuildDuckLakeJoinTerms(DeltaOperatorInput in
 			mul_binding = rewritten.mul_binding;
 			subtree_ref = std::move(rewritten.op);
 		}
-		UpdateParentProjectionMap(term, term_leaves[i]);
+		UpdateParentProjectionMap(term, term_leaves[i].path, term_leaves[i].node, /*include_delim_parents=*/false);
 
 		// Telescoping: pin leaves j > i to old snapshot (AT VERSION).
 		// Leaves j < i stay at current state (already the default).

--- a/src/delta/operators/join.cpp
+++ b/src/delta/operators/join.cpp
@@ -4,6 +4,7 @@
 #include "delta/operators/join_key_probe.hpp"
 #include "core/openivm_constants.hpp"
 #include "core/openivm_debug.hpp"
+#include "core/refresh_metadata.hpp"
 #include "core/sql_utils.hpp"
 #include "upsert/refresh_index_regen.hpp"
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
@@ -436,26 +437,31 @@ static void DemoteLeftJoinsForMask(LogicalOperator *node, const vector<JoinLeafI
 	DemoteLeftJoinsForMaskRec(node, leaves, mask, path);
 }
 
-void UpdateParentProjectionMap(unique_ptr<LogicalOperator> &term, const JoinLeafInfo &leaf) {
-	if (leaf.path.empty()) {
+void UpdateParentProjectionMap(unique_ptr<LogicalOperator> &term, const vector<size_t> &path,
+                               LogicalOperator *leaf_node, bool include_delim_parents) {
+	if (path.empty()) {
 		return;
 	}
-	size_t child_side = leaf.path.back();
+	size_t child_side = path.back();
 	unique_ptr<LogicalOperator> *parent = &term;
-	for (size_t s = 0; s + 1 < leaf.path.size(); s++) {
-		parent = &((*parent)->children[leaf.path[s]]);
+	for (size_t s = 0; s + 1 < path.size(); s++) {
+		parent = &((*parent)->children[path[s]]);
 	}
-	if ((*parent)->type == LogicalOperatorType::LOGICAL_COMPARISON_JOIN) {
-		auto *join = dynamic_cast<LogicalComparisonJoin *>((*parent).get());
-		if (join) {
-			auto &proj_map = (child_side == 0) ? join->left_projection_map : join->right_projection_map;
-			if (!proj_map.empty()) {
-				idx_t mul_idx = leaf.node->GetColumnBindings().size();
-				proj_map.push_back(mul_idx);
-				OPENIVM_DEBUG_PRINT("[DeltaJoin] Added mul col %lu to %s proj_map\n", (unsigned long)mul_idx,
-				                    child_side == 0 ? "left" : "right");
-			}
-		}
+	auto *join = dynamic_cast<LogicalComparisonJoin *>((*parent).get());
+	if (!join) {
+		return;
+	}
+	// The inclusion-exclusion path only patches plain comparison joins; the delim-join path also patches
+	// delim/dependent joins (also LogicalComparisonJoin subclasses).
+	if (!include_delim_parents && (*parent)->type != LogicalOperatorType::LOGICAL_COMPARISON_JOIN) {
+		return;
+	}
+	auto &proj_map = (child_side == 0) ? join->left_projection_map : join->right_projection_map;
+	if (!proj_map.empty()) {
+		idx_t mul_idx = leaf_node->GetColumnBindings().size();
+		proj_map.push_back(mul_idx);
+		OPENIVM_DEBUG_PRINT("[DeltaJoin] Added mul col %lu to %s proj_map\n", (unsigned long)mul_idx,
+		                    child_side == 0 ? "left" : "right");
 	}
 }
 
@@ -478,6 +484,7 @@ static DeltaStatus DetectDeltaStatus(ClientContext &context, const string &view_
 	DeltaStatus status = {0, 0, 0, 0};
 	Connection con(*context.db);
 	con.SetAutoCommit(false);
+	RefreshMetadata metadata(con);
 
 	for (size_t i = 0; i < leaves.size(); i++) {
 		LogicalGet *get = GetLeafScan(leaves[i]);
@@ -519,14 +526,11 @@ static DeltaStatus DetectDeltaStatus(ClientContext &context, const string &view_
 			continue;
 		}
 		string delta_name = SqlUtils::DeltaName(table_ref.get()->name);
-		// Get last_update timestamp for this view+table pair
-		auto ts_result = con.Query("SELECT last_update FROM " + string(openivm::DELTA_TABLES_TABLE) +
-		                           " WHERE view_name = '" + SqlUtils::EscapeValue(view_name) + "' AND table_name = '" +
-		                           SqlUtils::EscapeValue(delta_name) + "'");
-		if (ts_result->HasError() || ts_result->RowCount() == 0) {
+		// Get last_update timestamp for this view+table pair (empty == no tracked delta row → skip).
+		string last_update = metadata.GetLastUpdate(view_name, delta_name);
+		if (last_update.empty()) {
 			continue;
 		}
-		string last_update = ts_result->GetValue(0, 0).ToString();
 
 		// Single query: get pending delta count, delete count, and current base
 		// cardinality. The base count lets us define "tiny" as <= max(8 rows,
@@ -652,6 +656,34 @@ static uint64_t ComputeSkipBits(const vector<FKRelation> &fk_relations, uint64_t
 	return skip_bits;
 }
 
+unique_ptr<Expression> BuildMultiplicityProduct(Binder &binder, const LogicalType &mul_type,
+                                                const vector<ColumnBinding> &mul_bindings) {
+	FunctionBinder fbinder(binder);
+	unique_ptr<Expression> product = make_uniq<BoundColumnRefExpression>(mul_type, mul_bindings[0]);
+	for (size_t i = 1; i < mul_bindings.size(); i++) {
+		vector<unique_ptr<Expression>> args;
+		args.push_back(std::move(product));
+		args.push_back(make_uniq<BoundColumnRefExpression>(mul_type, mul_bindings[i]));
+		ErrorData err;
+		product = fbinder.BindScalarFunction(DEFAULT_SCHEMA, "*", std::move(args), err, true /* is_operator */);
+		if (!product) {
+			throw InternalException("DeltaJoin: failed to bind '*' for combined multiplicity: %s", err.RawMessage());
+		}
+	}
+	// Apply Möbius inclusion-exclusion sign: (-1)^(k-1). Only flip when k is even.
+	if (mul_bindings.size() % 2 == 0) {
+		vector<unique_ptr<Expression>> args;
+		args.push_back(make_uniq<BoundConstantExpression>(Value::INTEGER(-1)));
+		args.push_back(std::move(product));
+		ErrorData err;
+		product = fbinder.BindScalarFunction(DEFAULT_SCHEMA, "*", std::move(args), err, true);
+		if (!product) {
+			throw InternalException("DeltaJoin: failed to bind '*' for Möbius sign: %s", err.RawMessage());
+		}
+	}
+	return product;
+}
+
 // ============================================================================
 // BuildInclusionExclusionTerms: create 2^N - 1 delta terms
 // ============================================================================
@@ -694,6 +726,7 @@ static vector<unique_ptr<LogicalOperator>> BuildInclusionExclusionTerms(DeltaOpe
 	}
 
 	Connection key_probe_con(*context.db);
+	RefreshMetadata key_probe_metadata(key_probe_con);
 	vector<JoinColumnRef> leaf_refs(N);
 	vector<vector<DeltaJoinKeyProbe>> key_probes(N);
 	// Key-domain pruning can erase the last remaining term when exactly one input
@@ -719,17 +752,15 @@ static vector<unique_ptr<LogicalOperator>> BuildInclusionExclusionTerms(DeltaOpe
 			}
 			string table_name = table_ref.get()->name;
 			string delta_name = SqlUtils::DeltaName(table_name);
-			auto ts_result = key_probe_con.Query("SELECT last_update FROM " + string(openivm::DELTA_TABLES_TABLE) +
-			                                     " WHERE view_name = '" + SqlUtils::EscapeValue(input.context.view) +
-			                                     "' AND table_name = '" + SqlUtils::EscapeValue(delta_name) + "'");
-			if (ts_result->HasError() || ts_result->RowCount() == 0 || ts_result->GetValue(0, 0).IsNull()) {
+			string last_update = key_probe_metadata.GetLastUpdate(input.context.view, delta_name);
+			if (last_update.empty()) {
 				continue;
 			}
 			leaf_refs[i].leaf_index = i;
 			leaf_refs[i].get = get;
 			leaf_refs[i].table_name = table_name;
 			leaf_refs[i].delta_name = delta_name;
-			leaf_refs[i].last_update = ts_result->GetValue(0, 0).ToString();
+			leaf_refs[i].last_update = last_update;
 
 			auto leaf_bindings = leaves[i].node->GetColumnBindings();
 			for (auto &binding : leaf_bindings) {
@@ -836,7 +867,7 @@ static vector<unique_ptr<LogicalOperator>> BuildInclusionExclusionTerms(DeltaOpe
 					mul_bindings.push_back(rewritten.mul_binding);
 					subtree_ref = std::move(rewritten.op);
 				}
-				UpdateParentProjectionMap(term, leaves[i]);
+				UpdateParentProjectionMap(term, leaves[i].path, leaves[i].node, /*include_delim_parents=*/false);
 			}
 		}
 
@@ -878,31 +909,7 @@ static vector<unique_ptr<LogicalOperator>> BuildInclusionExclusionTerms(DeltaOpe
 		//   k=3: w_1·w_2·w_3         (no sign flip)
 		//   k=4: -w_1·w_2·w_3·w_4    (sign flip)
 		// — verified algebraically on all sign combinations.
-		FunctionBinder fbinder(binder);
-		unique_ptr<Expression> product = make_uniq<BoundColumnRefExpression>(input.mul_type, mul_bindings[0]);
-		for (size_t i = 1; i < mul_bindings.size(); i++) {
-			vector<unique_ptr<Expression>> args;
-			args.push_back(std::move(product));
-			args.push_back(make_uniq<BoundColumnRefExpression>(input.mul_type, mul_bindings[i]));
-			ErrorData err;
-			product = fbinder.BindScalarFunction(DEFAULT_SCHEMA, "*", std::move(args), err, true /* is_operator */);
-			if (!product) {
-				throw InternalException("DeltaJoin: failed to bind '*' for combined multiplicity: %s",
-				                        err.RawMessage());
-			}
-		}
-		// Apply Möbius sign: (-1)^(k-1). Only flip when k is even.
-		if (mul_bindings.size() % 2 == 0) {
-			vector<unique_ptr<Expression>> args;
-			args.push_back(make_uniq<BoundConstantExpression>(Value::INTEGER(-1)));
-			args.push_back(std::move(product));
-			ErrorData err;
-			product = fbinder.BindScalarFunction(DEFAULT_SCHEMA, "*", std::move(args), err, true);
-			if (!product) {
-				throw InternalException("DeltaJoin: failed to bind '*' for Möbius sign: %s", err.RawMessage());
-			}
-		}
-		proj_exprs.push_back(std::move(product));
+		proj_exprs.push_back(BuildMultiplicityProduct(binder, input.mul_type, mul_bindings));
 
 		auto projection = make_uniq<LogicalProjection>(binder.GenerateTableIndex(), std::move(proj_exprs));
 		projection->children.push_back(std::move(term));

--- a/src/include/core/ivm_view_classifier.hpp
+++ b/src/include/core/ivm_view_classifier.hpp
@@ -184,6 +184,10 @@ struct DeltaViewModel {
 	vector<DeltaLineageFact> lineage_facts;
 	vector<RefreshMetadata::WindowPartitionLineageOp> window_lineage_ops;
 	RefreshMetadata::ProjectionKeyLineage projection_lineage;
+	// Lineage of the hidden openivm_left_key column back to its preserved-side source binding, used to
+	// push the affected-key filter into the LEFT JOIN recompute (generic replacement for the former
+	// fact_market_history hardcode). Reuses the projection-key lineage struct with a single identity arm.
+	RefreshMetadata::ProjectionKeyLineage left_join_key_lineage;
 	idx_t root_node = DConstants::INVALID_INDEX;
 	string full_outer_join_cols;
 	GroupRecomputeAffectedMode group_recompute_affected_mode = GroupRecomputeAffectedMode::SOURCE_DELTA;
@@ -194,6 +198,7 @@ struct DeltaViewModel {
 	bool distinct_at_top = false;
 	bool union_distinct_over_agg = false;
 	bool has_projection_lineage = false;
+	bool has_left_join_key_lineage = false;
 	bool warn_unsupported_incremental = false;
 	bool warn_unrecognized_pattern = false;
 
@@ -213,6 +218,8 @@ struct DeltaViewModel {
 const char *DeltaStrategyReasonName(DeltaStrategyReason reason);
 const char *DeltaModelFeatureName(DeltaModelFeature feature);
 const char *DeltaModelNodeKindName(DeltaModelNodeKind kind);
+// Map a logical operator to its delta-model node kind (operator-type -> kind, the inverse of the dispatch).
+DeltaModelNodeKind NodeKindForOperator(LogicalOperator &op);
 const char *DeltaRuleKindName(DeltaRuleKind kind);
 const char *DeltaUnsupportedReasonName(DeltaUnsupportedReason reason);
 const char *DeltaUpdateSemanticsName(DeltaUpdateSemantics semantics);

--- a/src/include/core/parser_plan_helpers.hpp
+++ b/src/include/core/parser_plan_helpers.hpp
@@ -120,9 +120,14 @@ void ResolveWindowPartitionOutputNames(const CreateMVPlanFacts &facts, vector<st
 string BuildRefreshLineageJson(const vector<string> &entries);
 bool BuildWindowPartitionLineageOps(const CreateMVPlanFacts &facts, const vector<string> &partition_columns,
                                     vector<RefreshMetadata::WindowPartitionLineageOp> &out,
-                                    vector<RefreshMetadata::WindowPartitionLineageOp> *direct_out = nullptr);
+                                    vector<RefreshMetadata::WindowPartitionLineageOp> *direct_out = nullptr,
+                                    bool *out_unsafe_lookup = nullptr);
 bool BuildProjectionKeyLineage(const CreateMVPlanFacts &facts, const vector<string> &output_names,
                                RefreshMetadata::ProjectionKeyLineage &out);
+// Trace the hidden openivm_left_key column to the preserved-side source binding of the first outer join,
+// producing a single-arm ProjectionKeyLineage. Returns false (caller falls back to full LEFT JOIN
+// recompute) when the key is derived/multi-source or the source cannot be resolved.
+bool BuildLeftJoinKeyLineage(const CreateMVPlanFacts &facts, RefreshMetadata::ProjectionKeyLineage &out);
 void ResolveAggregateGroupColumnsThroughJoinKeys(const CreateMVPlanFacts &facts, vector<string> &aggregate_columns,
                                                  const vector<string> &output_names);
 string ExtractFullOuterJoinMetadata(const CreateMVPlanFacts &facts);

--- a/src/include/core/refresh_metadata.hpp
+++ b/src/include/core/refresh_metadata.hpp
@@ -5,6 +5,8 @@
 #include "duckdb/main/connection.hpp"
 #include "core/openivm_constants.hpp"
 
+#include <unordered_map>
+
 namespace duckdb {
 
 // Centralized access to IVM metadata stored in system tables.
@@ -12,6 +14,25 @@ namespace duckdb {
 // behind typed methods. Takes a Connection reference — does NOT create its own.
 class RefreshMetadata {
 	Connection &con;
+
+	// The definition-stable columns of one openivm_views row. These are written once at
+	// CREATE (a CREATE OR REPLACE is a fresh statement with a fresh RefreshMetadata) and never
+	// mutated during a refresh, so they are memoized per-instance to collapse the half-dozen
+	// single-column round-trips that GenerateRefreshSQL used to issue per refresh.
+	struct ViewMetaRow {
+		bool found = false;
+		string sql_string;
+		RefreshType type {};
+		bool has_minmax = false;
+		bool has_left_join = false;
+		bool has_full_outer = false;
+		string full_outer_join_cols;
+	};
+	const ViewMetaRow &GetViewMeta(const string &view_name);
+	std::unordered_map<string, ViewMetaRow> view_meta_cache;
+	std::unordered_map<string, vector<string>> group_columns_cache;
+	std::unordered_map<string, vector<string>> aggregate_types_cache;
+	std::unordered_map<string, vector<string>> delta_tables_cache;
 
 public:
 	explicit RefreshMetadata(Connection &con) : con(con) {
@@ -242,6 +263,11 @@ public:
 
 	bool GetProjectionKeyLineage(const string &view_name, ProjectionKeyLineage &out);
 	static string ProjectionKeyLineageToJson(const ProjectionKeyLineage &lineage);
+
+	// openivm_left_key → preserved-side source lineage, persisted as a "left_join_key" entry. Reuses the
+	// ProjectionKeyLineage shape (a single identity arm). Drives the generic LEFT JOIN affected-key pushdown.
+	bool GetLeftJoinKeyLineage(const string &view_name, ProjectionKeyLineage &out);
+	static string LeftJoinKeyLineageToJson(const ProjectionKeyLineage &lineage);
 
 	struct FilteredGroupCountAuxMeta {
 		string aux_table;

--- a/src/include/core/sql_utils.hpp
+++ b/src/include/core/sql_utils.hpp
@@ -28,6 +28,9 @@ public:
 	static string SQLStatementPreview(const string &statement);
 	static string DeltaName(const string &name);
 	static string LastIdentifierPart(string name);
+	// Last identifier part with the IVM data-table prefix stripped (and the delta prefix too when
+	// strip_delta is set). Used to compare tracked table names against their logical base names.
+	static string StripTrackedTablePrefix(const string &name, bool strip_delta = false);
 	static string FullName(const string &catalog, const string &schema, const string &table);
 	static string FullDeltaName(const string &catalog, const string &schema, const string &table);
 	static string QualifiedPrefix(const string &catalog, const string &schema);
@@ -36,6 +39,12 @@ public:
 	static string JsonArray(const vector<string> &values);
 	static string DuckLakeTableFunction(const string &function_name, const string &catalog, const string &schema,
 	                                    const string &table, int64_t last_snapshot_id, int64_t current_snapshot_id);
+	// Build a DuckLake change feed for [last_snapshot_id, current_snapshot_id):
+	//   (<select_list> FROM ...insertions UNION ALL <select_list> FROM ...deletions)
+	// select_list is applied to both branches (e.g. "*", or "col AS alias").
+	static string BuildDuckLakeChangeFeed(const string &catalog, const string &schema, const string &table,
+	                                      int64_t last_snapshot_id, int64_t current_snapshot_id,
+	                                      const string &select_list);
 	static bool GetBoolSetting(ClientContext &context, const string &setting_name, bool default_value) {
 		Value setting_value;
 		if (context.TryGetCurrentSetting(setting_name, setting_value) && !setting_value.IsNull()) {

--- a/src/include/delta/operators/join.hpp
+++ b/src/include/delta/operators/join.hpp
@@ -24,13 +24,27 @@ unique_ptr<LogicalOperator> &GetNodeAtPath(unique_ptr<LogicalOperator> &root, co
 
 void DemoteLeftJoins(LogicalOperator *node);
 
-void UpdateParentProjectionMap(unique_ptr<LogicalOperator> &term, const JoinLeafInfo &leaf);
+// Append the multiplicity column to the parent join's projection map for the leaf at `path`.
+// include_delim_parents=false matches only plain comparison joins (the inclusion-exclusion path);
+// =true also matches delim/dependent joins (the delim-join path). Behavior-preserving union of the
+// former join-side and delim-side helpers.
+void UpdateParentProjectionMap(unique_ptr<LogicalOperator> &term, const vector<size_t> &path,
+                               LogicalOperator *leaf_node, bool include_delim_parents);
 
 unique_ptr<LogicalOperator> AssembleJoinUnionAll(vector<unique_ptr<LogicalOperator>> &terms,
                                                  const vector<LogicalType> &types, Binder &binder);
 
 ColumnBinding ReplaceJoinOutputBindings(const vector<ColumnBinding> &original_bindings,
                                         unique_ptr<LogicalOperator> &result, LogicalOperator &root);
+
+// Build the combined multiplicity expression for one inclusion-exclusion term:
+//   (-1)^(k-1) * ∏ wᵢ   where k = mul_bindings.size()
+// i.e. the Z-set bilinear product of the per-leaf multiplicities times the Möbius
+// inclusion-exclusion sign (flip only when k is even). Shared by the 2^N-1 join rule
+// and the delim-join rule. See the call site in CompileJoinDelta for why the sign is
+// required by OpenIVM's "current base = R_old + ΔR" data layout.
+unique_ptr<Expression> BuildMultiplicityProduct(Binder &binder, const LogicalType &mul_type,
+                                                const vector<ColumnBinding> &mul_bindings);
 
 } // namespace duckdb
 

--- a/src/include/upsert/refresh_internal.hpp
+++ b/src/include/upsert/refresh_internal.hpp
@@ -27,6 +27,27 @@ struct DuckLakeSourceLocation {
 	string table_name;
 };
 
+// A DuckLake source table resolved for snapshot-diff refresh: its metadata key, physical location, and the
+// [old_snap, current_snap) range to diff. Shared by the projection-key and window-partition refresh paths.
+struct DuckLakeSourceSpec {
+	string metadata_key;
+	DuckLakeSourceLocation loc;
+	int64_t old_snap = -1;
+	int64_t current_snap = -1;
+};
+
+// Resolve every delta source for a view to a DuckLakeSourceSpec. Returns false (caller falls back) if any
+// source is not DuckLake-backed or its location/snapshots cannot be resolved.
+bool BuildDuckLakeSourceSpecs(RefreshMetadata &metadata, Connection &con, const string &view_name,
+                              const vector<string> &delta_table_names, const string &view_catalog_name,
+                              const string &view_schema_name, const string &attached_db_catalog_name,
+                              const string &attached_db_schema_name, vector<DuckLakeSourceSpec> &specs);
+// Find the spec whose metadata key or physical table name matches table_name (prefix-insensitive).
+const DuckLakeSourceSpec *FindDuckLakeSourceSpec(const vector<DuckLakeSourceSpec> &specs, const string &table_name);
+// (insertions UNION ALL deletions) over a DuckLake source's snapshot range, projecting source_col AS output_col.
+string BuildDuckLakeChangedValuesSQL(const DuckLakeSourceSpec &spec, const string &source_col,
+                                     const string &output_col);
+
 struct DeltaFastPathFlags {
 	bool insert_only = false;
 	bool skip_agg_delete = false;

--- a/src/upsert/refresh_compiler.cpp
+++ b/src/upsert/refresh_compiler.cpp
@@ -1185,15 +1185,8 @@ string CompileGroupRecompute(const string &view_name, const string &view_query_s
 
 		string delta_subselect;
 		if (spec.is_ducklake) {
-			delta_subselect =
-			    "(SELECT * FROM " +
-			    SqlUtils::DuckLakeTableFunction("ducklake_table_insertions", spec.ducklake_catalog,
-			                                    spec.ducklake_schema, base, spec.last_snapshot_id,
-			                                    spec.current_snapshot_id) +
-			    "\nUNION ALL\nSELECT * FROM " +
-			    SqlUtils::DuckLakeTableFunction("ducklake_table_deletions", spec.ducklake_catalog, spec.ducklake_schema,
-			                                    base, spec.last_snapshot_id, spec.current_snapshot_id) +
-			    ")";
+			delta_subselect = SqlUtils::BuildDuckLakeChangeFeed(spec.ducklake_catalog, spec.ducklake_schema, base,
+			                                                    spec.last_snapshot_id, spec.current_snapshot_id, "*");
 		} else {
 			string delta_basename = string(openivm::DELTA_PREFIX) + base;
 			delta_subselect =

--- a/src/upsert/refresh_helpers.cpp
+++ b/src/upsert/refresh_helpers.cpp
@@ -272,47 +272,33 @@ string BuildAffectedKeyRefreshSQL(const string &data_table, const string &view_q
 	return result;
 }
 
-struct ProjectionKeySourceSpec {
-	string metadata_key;
-	DuckLakeSourceLocation loc;
-	int64_t old_snap = -1;
-	int64_t current_snap = -1;
-};
-
-static string StripOpenIVMDataPrefix(const string &name) {
-	static const string data_prefix(openivm::DATA_TABLE_PREFIX);
-	string last = SqlUtils::LastIdentifierPart(name);
-	if (last.size() > data_prefix.size() && last.rfind(data_prefix, 0) == 0) {
-		return last.substr(data_prefix.size());
-	}
-	return last;
+static bool DuckLakeSourceSpecMatches(const DuckLakeSourceSpec &spec, const string &table_name) {
+	// metadata_key is a delta-table name, so strip the delta prefix too (matches the former window-path
+	// matcher; a harmless superset for the projection path, which also matches on loc.table_name).
+	return StringUtil::CIEquals(SqlUtils::StripTrackedTablePrefix(spec.metadata_key, /*strip_delta=*/true),
+	                            SqlUtils::StripTrackedTablePrefix(table_name, /*strip_delta=*/true)) ||
+	       StringUtil::CIEquals(SqlUtils::StripTrackedTablePrefix(spec.loc.table_name, /*strip_delta=*/true),
+	                            SqlUtils::StripTrackedTablePrefix(table_name, /*strip_delta=*/true));
 }
 
-static bool ProjectionSourceNameMatches(const ProjectionKeySourceSpec &spec, const string &table_name) {
-	return StringUtil::CIEquals(StripOpenIVMDataPrefix(spec.metadata_key), StripOpenIVMDataPrefix(table_name)) ||
-	       StringUtil::CIEquals(StripOpenIVMDataPrefix(spec.loc.table_name), StripOpenIVMDataPrefix(table_name));
-}
-
-static const ProjectionKeySourceSpec *FindProjectionSourceSpec(const vector<ProjectionKeySourceSpec> &specs,
-                                                               const string &table_name) {
+const DuckLakeSourceSpec *FindDuckLakeSourceSpec(const vector<DuckLakeSourceSpec> &specs, const string &table_name) {
 	for (auto &spec : specs) {
-		if (ProjectionSourceNameMatches(spec, table_name)) {
+		if (DuckLakeSourceSpecMatches(spec, table_name)) {
 			return &spec;
 		}
 	}
 	return nullptr;
 }
 
-static bool BuildProjectionKeySourceSpecs(RefreshMetadata &metadata, Connection &con, const string &view_name,
-                                          const vector<string> &delta_table_names, const string &view_catalog_name,
-                                          const string &view_schema_name, const string &attached_db_catalog_name,
-                                          const string &attached_db_schema_name,
-                                          vector<ProjectionKeySourceSpec> &specs) {
+bool BuildDuckLakeSourceSpecs(RefreshMetadata &metadata, Connection &con, const string &view_name,
+                              const vector<string> &delta_table_names, const string &view_catalog_name,
+                              const string &view_schema_name, const string &attached_db_catalog_name,
+                              const string &attached_db_schema_name, vector<DuckLakeSourceSpec> &specs) {
 	for (auto &dt : delta_table_names) {
 		if (!metadata.IsDuckLakeTable(view_name, dt)) {
 			return false;
 		}
-		ProjectionKeySourceSpec spec;
+		DuckLakeSourceSpec spec;
 		spec.metadata_key = dt;
 		spec.loc = ResolveDuckLakeSourceLocation(con, view_name, dt, view_catalog_name, view_schema_name,
 		                                         attached_db_catalog_name, attached_db_schema_name);
@@ -327,31 +313,23 @@ static bool BuildProjectionKeySourceSpecs(RefreshMetadata &metadata, Connection 
 	return !specs.empty();
 }
 
-static string BuildProjectionChangedValuesSQL(const ProjectionKeySourceSpec &spec, const string &source_col,
-                                              const string &output_col) {
-	string qsource_col = SqlUtils::QuoteIdentifier(source_col);
-	string qoutput_col = SqlUtils::QuoteIdentifier(output_col);
-	string insertions =
-	    "SELECT " + qsource_col + " AS " + qoutput_col + " FROM " +
-	    SqlUtils::DuckLakeTableFunction("ducklake_table_insertions", spec.loc.catalog_name, spec.loc.schema_name,
-	                                    spec.loc.table_name, spec.old_snap, spec.current_snap);
-	string deletions =
-	    "SELECT " + qsource_col + " AS " + qoutput_col + " FROM " +
-	    SqlUtils::DuckLakeTableFunction("ducklake_table_deletions", spec.loc.catalog_name, spec.loc.schema_name,
-	                                    spec.loc.table_name, spec.old_snap, spec.current_snap);
-	return "(" + insertions + " UNION ALL " + deletions + ")";
+string BuildDuckLakeChangedValuesSQL(const DuckLakeSourceSpec &spec, const string &source_col,
+                                     const string &output_col) {
+	string select_list = SqlUtils::QuoteIdentifier(source_col) + " AS " + SqlUtils::QuoteIdentifier(output_col);
+	return SqlUtils::BuildDuckLakeChangeFeed(spec.loc.catalog_name, spec.loc.schema_name, spec.loc.table_name,
+	                                         spec.old_snap, spec.current_snap, select_list);
 }
 
 static string BuildProjectionLineageArmSQL(const RefreshMetadata::ProjectionKeyLineageArm &arm,
-                                           const vector<ProjectionKeySourceSpec> &specs, const string &output_col,
+                                           const vector<DuckLakeSourceSpec> &specs, const string &output_col,
                                            bool current_snapshot) {
-	auto *source_spec = FindProjectionSourceSpec(specs, arm.source);
+	auto *source_spec = FindDuckLakeSourceSpec(specs, arm.source);
 	if (!source_spec) {
 		return "";
 	}
-	string sql = BuildProjectionChangedValuesSQL(*source_spec, arm.source_col, "openivm_lineage_key");
+	string sql = BuildDuckLakeChangedValuesSQL(*source_spec, arm.source_col, "openivm_lineage_key");
 	for (auto &step : arm.steps) {
-		auto *lookup_spec = FindProjectionSourceSpec(specs, step.table);
+		auto *lookup_spec = FindDuckLakeSourceSpec(specs, step.table);
 		if (!lookup_spec) {
 			return "";
 		}
@@ -375,12 +353,12 @@ bool TryBuildDuckLakeProjectionKeyRefresh(RefreshMetadata &metadata, Connection 
 		return false;
 	}
 
-	vector<ProjectionKeySourceSpec> specs;
-	if (!BuildProjectionKeySourceSpecs(metadata, con, view_name, delta_table_names, view_catalog_name, view_schema_name,
-	                                   attached_db_catalog_name, attached_db_schema_name, specs)) {
+	vector<DuckLakeSourceSpec> specs;
+	if (!BuildDuckLakeSourceSpecs(metadata, con, view_name, delta_table_names, view_catalog_name, view_schema_name,
+	                              attached_db_catalog_name, attached_db_schema_name, specs)) {
 		return false;
 	}
-	auto *key_spec = FindProjectionSourceSpec(specs, lineage.key_source);
+	auto *key_spec = FindDuckLakeSourceSpec(specs, lineage.key_source);
 	if (!key_spec) {
 		return false;
 	}
@@ -649,68 +627,76 @@ static string BuildFullOuterProjectionRefresh(RefreshMetadata &metadata, const s
 	                                   affected_ctes);
 }
 
-static string TryBuildLeftJoinAffectedPushdown(const string &view_name, const string &data_table,
-                                               const string &view_query_sql, const string &qdv,
-                                               const string &delta_ts_filter, const string &lk) {
-	static const string security_table = string(openivm::DATA_TABLE_PREFIX) + "dim_security";
-	static const string security_key = "sk_company_id";
-
-	if (!StringUtil::CIEquals(view_name, "fact_market_history")) {
+// Push the affected-key filter into the source binding that produces openivm_left_key, so the LEFT JOIN
+// recompute only reads source rows whose key changed. Driven by the create-time left_join_key lineage
+// (CREATE traced openivm_left_key to a single base-source identity column). Returns "" — caller falls back
+// to full recompute — whenever the lineage is absent, not a single identity arm, or the source reference
+// cannot be located in the stored query.
+//
+// The final INSERT-side EXISTS guard against openivm_affected keeps this semantics-preserving even if the
+// pushed source filter admits false positives: a left-side insert produces a new openivm_left_key in the
+// view delta, whose source row passes the pushed EXISTS, so no affected group is missed. We never push when
+// the key cannot be pinned to a single source binding.
+static string TryBuildLeftJoinAffectedPushdown(RefreshMetadata &metadata, const string &view_name,
+                                               const string &data_table, const string &view_query_sql,
+                                               const string &qdv, const string &delta_ts_filter, const string &lk) {
+	RefreshMetadata::ProjectionKeyLineage lineage;
+	if (!metadata.GetLeftJoinKeyLineage(view_name, lineage)) {
 		return "";
 	}
-
-	auto lower_query = StringUtil::Lower(view_query_sql);
-	if (view_query_sql.find(openivm::LEFT_KEY_COL) == string::npos || lower_query.find(security_key) == string::npos) {
-		return "";
+	if (lineage.arms.size() != 1 || !lineage.arms[0].steps.empty()) {
+		return ""; // derived / multi-source key — not safe to push generically
 	}
-	if (lower_query.find("openivm_data_daily_market") == string::npos ||
-	    lower_query.find("openivm_data_financial") == string::npos ||
-	    lower_query.find("openivm_data_dim_company") == string::npos) {
-		return "";
+	// The pushdown rewrites the source by its logical name; a DuckLake source lives in an attached catalog
+	// (e.g. dl.CUSTOMER) and would lose its qualification, so fall back to full recompute for any DuckLake
+	// view (the recompute path resolves the qualified name correctly).
+	for (auto &dt : metadata.GetDeltaTables(view_name)) {
+		if (metadata.IsDuckLakeTable(view_name, dt)) {
+			return "";
+		}
 	}
 
-	auto source_ref = SqlUtils::FindTableReference(view_query_sql, security_table);
-	if (source_ref.empty()) {
+	string key_col = KeywordHelper::WriteOptionallyQuoted(lineage.key_col);
+	auto push_into = [&](const string &source_name) -> string {
+		string replacement = "(SELECT * FROM " + source_name +
+		                     " openivm_lj_src WHERE EXISTS (SELECT 1 FROM openivm_affected openivm_lj_aff WHERE "
+		                     "openivm_lj_src." +
+		                     key_col + " IS NOT DISTINCT FROM openivm_lj_aff." + lk + "))";
+		bool replaced = false;
+		string pushed = SqlUtils::ReplaceTableReferenceOccurrence(view_query_sql, source_name, lineage.key_occurrence,
+		                                                          replacement, replaced);
+		return (replaced && pushed != view_query_sql) ? pushed : "";
+	};
+	// The stored query references either the logical source name or, for an MV-on-MV source, its data table.
+	string pushed_query = push_into(lineage.key_source);
+	if (pushed_query.empty()) {
+		pushed_query = push_into(string(openivm::DATA_TABLE_PREFIX) + lineage.key_source);
+	}
+	if (pushed_query.empty()) {
 		return "";
 	}
 
 	string affected_where = delta_ts_filter.empty() ? "" : " WHERE " + delta_ts_filter;
 	string affected_cte =
 	    "WITH openivm_affected AS (\n  SELECT DISTINCT " + lk + " FROM " + qdv + affected_where + "\n)\n";
-	string key_col = KeywordHelper::WriteOptionallyQuoted(security_key);
-	string replacement = "(SELECT * FROM " + source_ref +
-	                     " openivm_lj_src WHERE EXISTS (SELECT 1 FROM openivm_affected openivm_lj_aff WHERE "
-	                     "openivm_lj_src." +
-	                     key_col + " IS NOT DISTINCT FROM openivm_lj_aff." + lk + "))";
-
-	auto pushed_query = SqlUtils::ReplaceTableReferences(view_query_sql, security_table, replacement);
-	if (pushed_query == view_query_sql) {
-		return "";
-	}
-
 	string affected = "EXISTS (SELECT 1 FROM openivm_affected _d WHERE _d." + lk + " IS NOT DISTINCT FROM ";
 	string delete_match = "_d." + lk + " IS NOT DISTINCT FROM openivm_delete_target." + lk;
-	// TODO(PROPER Lineage): replace this TPC-DI source-specific shortcut with lineage from
-	// openivm_left_key to the source binding that produced it, then push the affected-key
-	// predicate to that binding generically. The final EXISTS guard stays because it makes
-	// this rewrite semantics-preserving even if the source filter admits false positives.
-	// This must not be generalized by table/column names alone: left-side inserts can produce
-	// false negatives unless lineage proves the affected key comes from this source binding.
-	// We also benchmarked dropping the final guard at SF25/SF50; it was only marginally
-	// faster, so the guarded shape is the safer default until lineage proves exactness.
+	OPENIVM_DEBUG_PRINT("[UPSERT] LEFT JOIN affected-key pushdown for %s via %s[%llu].%s\n", view_name.c_str(),
+	                    lineage.key_source.c_str(), static_cast<unsigned long long>(lineage.key_occurrence),
+	                    lineage.key_col.c_str());
 	return BuildDeleteUsingInsertRefreshSQL(data_table, pushed_query, "openivm_lj", "openivm_affected", "_d",
 	                                        delete_match, affected + "openivm_lj." + lk + ")", affected_cte);
 }
 
-static string BuildLeftJoinProjectionRefresh(const string &view_name, const string &data_table,
-                                             const string &view_query_sql, const string &delta_ts_filter,
-                                             const string &catalog_prefix) {
+static string BuildLeftJoinProjectionRefresh(RefreshMetadata &metadata, const string &view_name,
+                                             const string &data_table, const string &view_query_sql,
+                                             const string &delta_ts_filter, const string &catalog_prefix) {
 	string delta_where = delta_ts_filter.empty() ? "" : " AND " + delta_ts_filter;
 	string qdv = catalog_prefix + KeywordHelper::WriteOptionallyQuoted(SqlUtils::DeltaName(view_name));
 	string lk = KeywordHelper::WriteOptionallyQuoted(string(openivm::LEFT_KEY_COL));
 	string affected = "EXISTS (SELECT 1 FROM " + qdv + " _d WHERE _d." + lk + " IS NOT DISTINCT FROM ";
 	auto pushed_refresh =
-	    TryBuildLeftJoinAffectedPushdown(view_name, data_table, view_query_sql, qdv, delta_ts_filter, lk);
+	    TryBuildLeftJoinAffectedPushdown(metadata, view_name, data_table, view_query_sql, qdv, delta_ts_filter, lk);
 	if (!pushed_refresh.empty()) {
 		return pushed_refresh;
 	}
@@ -729,7 +715,8 @@ string CompileProjectionRefresh(RefreshMetadata &metadata, const string &view_na
 		                                       delta_ts_filter, catalog_prefix);
 	}
 	if (has_left_join) {
-		return BuildLeftJoinProjectionRefresh(view_name, data_table, view_query_sql, delta_ts_filter, catalog_prefix);
+		return BuildLeftJoinProjectionRefresh(metadata, view_name, data_table, view_query_sql, delta_ts_filter,
+		                                      catalog_prefix);
 	}
 	return CompileProjectionsFilters(view_name, column_names, delta_ts_filter, catalog_prefix, skip_proj_delete);
 }

--- a/src/upsert/refresh_window.cpp
+++ b/src/upsert/refresh_window.cpp
@@ -68,22 +68,10 @@ static bool IsSafeForDuckLakeSnapshotDiff(const vector<string> &partition_cols, 
 	return true;
 }
 
-static string StripTrackedPrefix(const string &name) {
-	static const string data_prefix(openivm::DATA_TABLE_PREFIX);
-	static const string delta_prefix(openivm::DELTA_PREFIX);
-	string last = SqlUtils::LastIdentifierPart(name);
-	if (last.size() > data_prefix.size() && last.rfind(data_prefix, 0) == 0) {
-		return last.substr(data_prefix.size());
-	}
-	if (last.size() > delta_prefix.size() && last.rfind(delta_prefix, 0) == 0) {
-		return last.substr(delta_prefix.size());
-	}
-	return last;
-}
-
 static string FindTrackedDeltaKey(const vector<string> &delta_table_names, const string &table_name) {
 	for (auto &dt : delta_table_names) {
-		if (StringUtil::CIEquals(StripTrackedPrefix(dt), StripTrackedPrefix(table_name))) {
+		if (StringUtil::CIEquals(SqlUtils::StripTrackedTablePrefix(dt, true),
+		                         SqlUtils::StripTrackedTablePrefix(table_name, true))) {
 			return dt;
 		}
 	}
@@ -195,11 +183,11 @@ static bool BuildLineageStandardAffectedKeysSQL(RefreshMetadata &metadata, const
 			continue;
 		}
 		arms.push_back("(" + arm_sql + ")");
-		covered_sources.insert(StripTrackedPrefix(op.source));
+		covered_sources.insert(SqlUtils::StripTrackedTablePrefix(op.source, true));
 	}
 
 	for (auto &dt : delta_table_names) {
-		if (!covered_sources.count(StripTrackedPrefix(dt))) {
+		if (!covered_sources.count(SqlUtils::StripTrackedTablePrefix(dt, true))) {
 			return false;
 		}
 	}
@@ -232,81 +220,8 @@ static bool AllWindowPartitionSourcesCovered(const vector<string> &delta_table_n
 	return !delta_table_names.empty();
 }
 
-struct DuckLakeWindowSourceSpec {
-	string metadata_key;
-	DuckLakeSourceLocation loc;
-	int64_t old_snap = -1;
-	int64_t current_snap = -1;
-};
-
-static string StripDataPrefix(const string &name) {
-	static const string data_prefix(openivm::DATA_TABLE_PREFIX);
-	string last = SqlUtils::LastIdentifierPart(name);
-	if (last.size() > data_prefix.size() && last.rfind(data_prefix, 0) == 0) {
-		return last.substr(data_prefix.size());
-	}
-	return last;
-}
-
-static bool NamesMatch(const string &left, const string &right) {
-	return StringUtil::CIEquals(StripDataPrefix(left), StripDataPrefix(right));
-}
-
-static bool SourceSpecMatches(const DuckLakeWindowSourceSpec &spec, const string &table_name) {
-	return NamesMatch(spec.metadata_key, table_name) || NamesMatch(spec.loc.table_name, table_name);
-}
-
-static const DuckLakeWindowSourceSpec *FindSourceSpec(const vector<DuckLakeWindowSourceSpec> &specs,
-                                                      const string &table_name) {
-	for (auto &spec : specs) {
-		if (SourceSpecMatches(spec, table_name)) {
-			return &spec;
-		}
-	}
-	return nullptr;
-}
-
-static bool BuildDuckLakeWindowSourceSpecs(RefreshMetadata &metadata, Connection &con, const string &view_name,
-                                           const vector<string> &delta_table_names, const string &view_catalog_name,
-                                           const string &view_schema_name, const string &attached_db_catalog_name,
-                                           const string &attached_db_schema_name,
-                                           vector<DuckLakeWindowSourceSpec> &specs) {
-	for (auto &dt : delta_table_names) {
-		if (!metadata.IsDuckLakeTable(view_name, dt)) {
-			return false;
-		}
-		DuckLakeWindowSourceSpec spec;
-		spec.metadata_key = dt;
-		spec.loc = ResolveDuckLakeSourceLocation(con, view_name, dt, view_catalog_name, view_schema_name,
-		                                         attached_db_catalog_name, attached_db_schema_name);
-		spec.old_snap = metadata.GetLastSnapshotId(view_name, dt);
-		spec.current_snap = metadata.GetCurrentDuckLakeSnapshot(spec.loc.catalog_name);
-		if (spec.loc.catalog_name.empty() || spec.loc.schema_name.empty() || spec.loc.table_name.empty() ||
-		    spec.old_snap < 0 || spec.current_snap < 0) {
-			return false;
-		}
-		specs.push_back(std::move(spec));
-	}
-	return !specs.empty();
-}
-
-static string BuildDuckLakeChangedValuesSQL(const DuckLakeWindowSourceSpec &spec, const string &source_col,
-                                            const string &output_col) {
-	string qsource_col = SqlUtils::QuoteIdentifier(source_col);
-	string qoutput_col = SqlUtils::QuoteIdentifier(output_col);
-	string insertions =
-	    "SELECT " + qsource_col + " AS " + qoutput_col + " FROM " +
-	    SqlUtils::DuckLakeTableFunction("ducklake_table_insertions", spec.loc.catalog_name, spec.loc.schema_name,
-	                                    spec.loc.table_name, spec.old_snap, spec.current_snap);
-	string deletions =
-	    "SELECT " + qsource_col + " AS " + qoutput_col + " FROM " +
-	    SqlUtils::DuckLakeTableFunction("ducklake_table_deletions", spec.loc.catalog_name, spec.loc.schema_name,
-	                                    spec.loc.table_name, spec.old_snap, spec.current_snap);
-	return "(" + insertions + " UNION ALL " + deletions + ")";
-}
-
-static string BuildDuckLakeLookupChangedKeysSQL(const DuckLakeWindowSourceSpec &source_spec,
-                                                const DuckLakeWindowSourceSpec &lookup_spec,
+static string BuildDuckLakeLookupChangedKeysSQL(const DuckLakeSourceSpec &source_spec,
+                                                const DuckLakeSourceSpec &lookup_spec,
                                                 const RefreshMetadata::WindowPartitionLineageOp &op) {
 	string changed = BuildDuckLakeChangedValuesSQL(source_spec, op.source_col, "openivm_join_key");
 	string lookup_table =
@@ -355,9 +270,9 @@ static bool BuildLineageDuckLakeAffectedKeysSQL(RefreshMetadata &metadata, Conne
 	key_cols = SqlUtils::QuoteIdentifier(parsed.first);
 	key_tuple = key_cols;
 
-	vector<DuckLakeWindowSourceSpec> specs;
-	if (!BuildDuckLakeWindowSourceSpecs(metadata, con, view_name, delta_table_names, view_catalog_name,
-	                                    view_schema_name, attached_db_catalog_name, attached_db_schema_name, specs)) {
+	vector<DuckLakeSourceSpec> specs;
+	if (!BuildDuckLakeSourceSpecs(metadata, con, view_name, delta_table_names, view_catalog_name, view_schema_name,
+	                              attached_db_catalog_name, attached_db_schema_name, specs)) {
 		return false;
 	}
 
@@ -372,27 +287,27 @@ static bool BuildLineageDuckLakeAffectedKeysSQL(RefreshMetadata &metadata, Conne
 		if (!StringUtil::CIEquals(op.output_col, parsed.first)) {
 			continue;
 		}
-		auto *source_spec = FindSourceSpec(specs, op.source);
+		auto *source_spec = FindDuckLakeSourceSpec(specs, op.source);
 		if (!source_spec) {
 			continue;
 		}
 		if (op.kind == "direct") {
 			arms.push_back(BuildDuckLakeChangedValuesSQL(*source_spec, op.source_col, op.output_col));
-			covered_sources.insert(StripDataPrefix(source_spec->metadata_key));
+			covered_sources.insert(SqlUtils::StripTrackedTablePrefix(source_spec->metadata_key));
 			continue;
 		}
 		if (op.kind == "lookup") {
-			auto *lookup_spec = FindSourceSpec(specs, op.lookup);
+			auto *lookup_spec = FindDuckLakeSourceSpec(specs, op.lookup);
 			if (!lookup_spec) {
 				continue;
 			}
 			arms.push_back(BuildDuckLakeLookupChangedKeysSQL(*source_spec, *lookup_spec, op));
-			covered_sources.insert(StripDataPrefix(source_spec->metadata_key));
+			covered_sources.insert(SqlUtils::StripTrackedTablePrefix(source_spec->metadata_key));
 		}
 	}
 
 	for (auto &spec : specs) {
-		if (!covered_sources.count(StripDataPrefix(spec.metadata_key))) {
+		if (!covered_sources.count(SqlUtils::StripTrackedTablePrefix(spec.metadata_key))) {
 			return false;
 		}
 	}

--- a/test/sql/left_join_affected_pushdown.test
+++ b/test/sql/left_join_affected_pushdown.test
@@ -1,0 +1,146 @@
+# name: test/sql/left_join_affected_pushdown.test
+# description: Generic lineage-driven LEFT JOIN affected-key pushdown (replaces the former fact_market_history hardcode)
+# group: [sql]
+
+require openivm
+
+statement ok
+SET openivm_cascade_refresh = 'off';
+
+statement ok
+SET openivm_files_path='__TEST_DIR__';
+
+# ============================================================
+# D1: inner joins feeding a LEFT JOIN; the preserved-side left key
+# flows from a single source (security). Same shape as fact_market_history.
+# ============================================================
+
+statement ok
+CREATE TABLE company(cid INT, cname VARCHAR);
+
+statement ok
+CREATE TABLE security(sk INT, cid INT, sname VARCHAR);
+
+statement ok
+CREATE TABLE market(sk INT, px INT);
+
+statement ok
+INSERT INTO company VALUES (10, 'Acme'), (20, 'Globex');
+
+statement ok
+INSERT INTO security VALUES (1, 10, 'ACM'), (2, 20, 'GLX');
+
+statement ok
+INSERT INTO market VALUES (1, 100);
+
+statement ok
+CREATE MATERIALIZED VIEW mh AS
+    SELECT sec.sk, sec.sname, c.cname, m.px
+    FROM company c JOIN security sec ON c.cid = sec.cid
+    LEFT JOIN market m ON sec.sk = m.sk;
+
+query I
+SELECT COUNT(*) FROM (
+  SELECT sec.sk, sec.sname, c.cname, m.px FROM company c JOIN security sec ON c.cid = sec.cid
+  LEFT JOIN market m ON sec.sk = m.sk
+  EXCEPT ALL SELECT * FROM mh
+);
+----
+0
+
+# Batch a mix of INSERT + DELETE across all three sources before one refresh.
+statement ok
+INSERT INTO market VALUES (2, 200);
+
+statement ok
+INSERT INTO security VALUES (3, 10, 'ACM2');
+
+statement ok
+INSERT INTO company VALUES (30, 'Initech');
+
+statement ok
+DELETE FROM market WHERE sk = 1;
+
+statement ok
+PRAGMA refresh('mh');
+
+# The lineage-driven pushdown must FIRE: the recompute query pushes an EXISTS on
+# the affected keys into the key's source binding.
+query I
+SELECT contains(content, 'openivm_lj_src') AND contains(content, 'openivm_affected')
+FROM read_text('__TEST_DIR__/openivm_upsert_queries_mh.sql');
+----
+true
+
+query I
+SELECT COUNT(*) FROM (
+  SELECT sec.sk, sec.sname, c.cname, m.px FROM company c JOIN security sec ON c.cid = sec.cid
+  LEFT JOIN market m ON sec.sk = m.sk
+  EXCEPT ALL SELECT * FROM mh
+);
+----
+0
+
+query I
+SELECT COUNT(*) FROM (
+  SELECT * FROM mh
+  EXCEPT ALL
+  SELECT sec.sk, sec.sname, c.cname, m.px FROM company c JOIN security sec ON c.cid = sec.cid
+  LEFT JOIN market m ON sec.sk = m.sk
+);
+----
+0
+
+# ============================================================
+# D2: derived (non-identity) left key -> no lineage -> full-recompute
+# fallback. Results must still be correct (the optimization is skipped, not wrong).
+# ============================================================
+
+statement ok
+CREATE TABLE la(k INT, v INT);
+
+statement ok
+CREATE TABLE lb(k INT, w INT);
+
+statement ok
+INSERT INTO la VALUES (1, 5), (2, 6);
+
+statement ok
+INSERT INTO lb VALUES (2, 99);
+
+statement ok
+CREATE MATERIALIZED VIEW mh2 AS
+    SELECT la.k, la.v, lb.w
+    FROM la LEFT JOIN lb ON la.k + 1 = lb.k;
+
+statement ok
+INSERT INTO lb VALUES (3, 100);
+
+statement ok
+INSERT INTO la VALUES (3, 7);
+
+statement ok
+PRAGMA refresh('mh2');
+
+# Derived join key: pushdown does not fire; falls back to full LEFT JOIN recompute.
+query I
+SELECT contains(content, 'openivm_lj_src') FROM read_text('__TEST_DIR__/openivm_upsert_queries_mh2.sql');
+----
+false
+
+query I
+SELECT COUNT(*) FROM (
+  SELECT la.k, la.v, lb.w FROM la LEFT JOIN lb ON la.k + 1 = lb.k
+  EXCEPT ALL SELECT * FROM mh2
+);
+----
+0
+
+query I
+SELECT COUNT(*) FROM (
+  SELECT * FROM mh2
+  EXCEPT ALL
+  SELECT la.k, la.v, lb.w FROM la LEFT JOIN lb ON la.k + 1 = lb.k
+);
+----
+0


### PR DESCRIPTION
## Summary

Engine hardening with **no behavior regressions**. Collapses duplicate code, makes the delta compiler's dispatch single-sourced, removes a hardcoded benchmark shortcut in favor of generic lineage, and cuts per-refresh metadata queries — plus two correctness fixes for edge cases the rewriter benchmark surfaced.

## What changed

- **Unified delta dispatch.** The three parallel switches (model / copied-subtree / non-model-leaf) collapse into one `DispatchDeltaCompile` keyed on `DeltaModelNodeKind`, with `NodeKindForOperator` exported as the single operator→kind source of truth. Adds a release-mode `ValidateDeltaFragment` enforcing the one-multiplicity-binding contract at every dispatch boundary. Behavior-preserving.

- **Generalized the LEFT JOIN affected-key pushdown.** Replaces the hardcoded `fact_market_history` shortcut with a generic `left_join_key` lineage (reusing the `ProjectionKeyLineage` machinery), with a clean full-recompute fallback when the key isn't a single identity column or the source is DuckLake-backed (avoids dropping catalog qualification). New test `test/sql/left_join_affected_pushdown.test`.

- **Batched metadata reads.** `RefreshMetadata` memoizes the definition-stable `openivm_views` columns (one row fetch backing the six single-column getters) plus `GetGroupColumns`/`GetAggregateTypes`/`GetDeltaTables`, collapsing the per-refresh query storm.

- **Window-partition correctness fix.** Falls back to `CURRENT_DIFF_RECOMPUTE` when an affected-key lookup join uses a cast-incomparable key (e.g. `CAST(cik AS VARCHAR) = company_id`, BIGINT vs VARCHAR) that the raw `col IN (lookup_col)` probe could not bind or could under-count. Numeric-vs-numeric keys keep the optimization.

- **Deduplicated helpers.** Shared `BuildMultiplicityProduct`, `DeltaJoinBindingKey`, `SqlUtils::BuildDuckLakeChangeFeed`, `SqlUtils::StripTrackedTablePrefix`, a unified `DuckLakeSourceSpec` + `BuildDuckLakeSourceSpecs`/`FindDuckLakeSourceSpec` (replacing the `ProjectionKeySourceSpec`/`DuckLakeWindowSourceSpec` clones), a shared `BuildDuckLakeChangedValuesSQL`, `RefreshMetadata::GetLastUpdate` at the two inline `join.cpp` lookups, and one parameterized `UpdateParentProjectionMap`.

- **Docs.** `CLAUDE.md` updated to describe the `src/delta/` IR + unified dispatch architecture (the old `src/rules/*` + `rule.hpp` layout no longer exists).

## Verification

- Unit suite: **56/56 (7726 assertions)**.
- Rewriter benchmark **TPC-DI: 45/45** correct, 0 failures, 0 classification mismatches.
- Rewriter benchmark **TPC-C: 2451/2451** correct (a final re-confirm with the last two changes is in progress).
- The generalized left-join pushdown and the window-partition fix were each cross-checked with bidirectional `EXCEPT ALL` against the base query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
