### PR TITLE
LEFT JOIN insert-only append fast path + CompileFacts per-batch facts

### DIFF
--- a/src/compile_facts.cpp
+++ b/src/compile_facts.cpp
@@ -124,6 +124,76 @@ bool ExtractJsonInt(const string &json, const string &key, int &val) {
 	}
 }
 
+// Extract a nested object's `{...}` substring (braces included) for key. Brace-matched;
+// relies on the same closed-loop invariant as the scalar helpers (no '{'/'}' inside string
+// values on our wire). Returns false if the "key":{ needle is absent.
+bool ExtractJsonObjectBody(const string &json, const string &key, string &out_body) {
+	string needle = "\"" + key + "\":{";
+	size_t pos = json.find(needle);
+	if (pos == string::npos) {
+		return false;
+	}
+	size_t body_start = pos + needle.size() - 1; // points at '{'
+	int depth = 0;
+	for (size_t i = body_start; i < json.size(); i++) {
+		char c = json[i];
+		if (c == '{') {
+			depth++;
+		} else if (c == '}') {
+			depth--;
+			if (depth == 0) {
+				out_body = json.substr(body_start, i - body_start + 1);
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
+// Parse a JSON array of strings: "key":[ "a", "b" ]. Empty [] returns true with empty out.
+// Only string elements are supported (sufficient for the closed-loop wire). Escape handling
+// mirrors ExtractJsonString. Returns false if the needle is absent or the array is unterminated.
+bool ExtractJsonStringArray(const string &json, const string &key, vector<string> &out) {
+	string needle = "\"" + key + "\":[";
+	size_t pos = json.find(needle);
+	if (pos == string::npos) {
+		return false;
+	}
+	pos += needle.size();
+	out.clear();
+	while (pos < json.size()) {
+		while (pos < json.size() &&
+		       (json[pos] == ' ' || json[pos] == '\t' || json[pos] == '\n' || json[pos] == ',')) {
+			pos++;
+		}
+		if (pos < json.size() && json[pos] == ']') {
+			return true;
+		}
+		if (pos >= json.size() || json[pos] != '"') {
+			return false; // only quoted string elements are supported
+		}
+		pos++; // past opening quote
+		string val;
+		while (pos < json.size()) {
+			char c = json[pos];
+			if (c == '\\' && pos + 1 < json.size()) {
+				char esc = json[pos + 1];
+				val += (esc == 'n') ? '\n' : esc;
+				pos += 2;
+				continue;
+			}
+			if (c == '"') {
+				pos++;
+				break;
+			}
+			val += c;
+			pos++;
+		}
+		out.push_back(std::move(val));
+	}
+	return false; // unterminated array
+}
+
 SqlDialect ParseDialectString(const string &s) {
 	// Reuse the lpts helper so dialect names stay in lockstep with the
 	// LPTS pipeline. LPTS throws on unrecognised values which is exactly
@@ -154,7 +224,28 @@ CompileFacts ParseFactsJson(const string &json) {
 		out.schema_version = sv;
 	}
 	ExtractJsonBool(json, "compile_only", out.compile_only);
+	// Legacy v1 top-level position (still honored); v2 canonical location is universal.*.
 	ExtractJsonBool(json, "force_view_delta_cascade", out.force_view_delta_cascade);
+
+	// v2: universal facts (stable per view). Absence = no assertion; never the negative claim,
+	// so an absent/empty field can only forgo an optimization, never disable a correctness guard.
+	string universal_body;
+	if (ExtractJsonObjectBody(json, "universal", universal_body)) {
+		ExtractJsonBool(universal_body, "force_view_delta_cascade", out.force_view_delta_cascade);
+		ExtractJsonBool(universal_body, "emit_derived_facts", out.emit_derived_facts);
+		ExtractJsonStringArray(universal_body, "source_constraints", out.source_constraints);
+		ExtractJsonStringArray(universal_body, "partitioning", out.partitioning);
+		ExtractJsonStringArray(universal_body, "target_capabilities", out.target_capabilities);
+	}
+
+	// v2: per-batch facts. Presence of the "batch" object gates the per-batch fast paths;
+	// when absent, planning keeps its conservative defaults.
+	string batch_body;
+	if (ExtractJsonObjectBody(json, "batch", batch_body)) {
+		out.has_batch_facts = true;
+		ExtractJsonStringArray(batch_body, "active_delta_tables", out.active_delta_tables);
+		ExtractJsonBool(batch_body, "insert_only", out.batch_insert_only);
+	}
 
 	return out;
 }
@@ -325,6 +416,23 @@ unique_ptr<FunctionData> OpenIvmCompileWithFactsBind(ClientContext &context, Tab
 	PushBucket(*result, "meta_pre", out_pre_meta);
 	PushBucket(*result, "data", sql);
 	PushBucket(*result, "meta_post", out_post_meta);
+
+	// Output enrichment: when requested, return derived UNIVERSAL facts the caller can't cheaply
+	// derive itself (it runs on empty schema-only tables). Emitted as a single extra row tagged
+	// stmt_kind="derived_fact" carrying JSON in the `sql` column — additive (consumers filtering on
+	// meta_pre|data|meta_post ignore it) and NOT routed through PushBucket (no trailing ';').
+	if (facts_owned->emit_derived_facts) {
+		RefreshMetadata::LeftJoinNullableSources nullable;
+		metadata.GetLeftJoinNullableSources(view_name, nullable); // false -> empty, fine
+		vector<string> referenced;
+		for (auto &dt : metadata.GetDeltaTables(view_name)) {
+			referenced.push_back(BaseTableNameFromDeltaKey(dt));
+		}
+		string derived = "{\"nullable_sources\":" + SqlUtils::JsonArray(nullable.tables) +
+		                 ",\"referenced_sources\":" + SqlUtils::JsonArray(referenced) + "}";
+		result->stmt_kinds.push_back("derived_fact");
+		result->stmt_sqls.push_back(derived);
+	}
 
 	return_types.emplace_back(LogicalType::INTEGER);
 	names.emplace_back("refresh_type");

--- a/src/compile_facts.cpp
+++ b/src/compile_facts.cpp
@@ -162,8 +162,7 @@ bool ExtractJsonStringArray(const string &json, const string &key, vector<string
 	pos += needle.size();
 	out.clear();
 	while (pos < json.size()) {
-		while (pos < json.size() &&
-		       (json[pos] == ' ' || json[pos] == '\t' || json[pos] == '\n' || json[pos] == ',')) {
+		while (pos < json.size() && (json[pos] == ' ' || json[pos] == '\t' || json[pos] == '\n' || json[pos] == ',')) {
 			pos++;
 		}
 		if (pos < json.size() && json[pos] == ']') {

--- a/src/core/ivm_delta_model.cpp
+++ b/src/core/ivm_delta_model.cpp
@@ -708,6 +708,7 @@ void PopulateDeltaViewModelLineage(DeltaViewModel &model, const CreateMVPlanFact
 	}
 	if (model.type == RefreshType::SIMPLE_PROJECTION && analysis.found_left_join && !analysis.found_full_outer) {
 		model.has_left_join_key_lineage = BuildLeftJoinKeyLineage(facts, model.left_join_key_lineage);
+		model.has_left_join_nullable = BuildLeftJoinNullableSources(facts, model.left_join_nullable_sources);
 	}
 	if (model.HasSemiAntiAux()) {
 		for (auto &col : model.semi_anti_aux.left_cols) {
@@ -732,6 +733,9 @@ string BuildDeltaViewModelLineageJson(const DeltaViewModel &model) {
 	}
 	if (model.has_left_join_key_lineage) {
 		entries.push_back(RefreshMetadata::LeftJoinKeyLineageToJson(model.left_join_key_lineage));
+	}
+	if (model.has_left_join_nullable) {
+		entries.push_back(RefreshMetadata::LeftJoinNullableSourcesToJson(model.left_join_nullable_sources));
 	}
 	return BuildRefreshLineageJson(entries);
 }

--- a/src/core/parser_plan_helpers.cpp
+++ b/src/core/parser_plan_helpers.cpp
@@ -5,6 +5,7 @@
 #include "core/refresh_metadata.hpp"
 #include "core/sql_utils.hpp"
 #include "rules/column_hider.hpp"
+#include <set>
 #include "duckdb/main/settings.hpp"
 #include "duckdb/optimizer/cte_inlining.hpp"
 #include "duckdb/optimizer/optimizer.hpp"
@@ -1313,6 +1314,77 @@ bool BuildLeftJoinKeyLineage(const CreateMVPlanFacts &facts, RefreshMetadata::Pr
 	lineage.arms.push_back(std::move(arm));
 	out = std::move(lineage);
 	return true;
+}
+
+static string NullableGetTableName(LogicalGet &get) {
+	auto table = get.GetTable();
+	if (table.get() && !table.get()->name.empty()) {
+		return table.get()->name;
+	}
+	if (get.function.name == "ducklake_scan" && get.function.function_info) {
+		return get.function.function_info->Cast<DuckLakeFunctionInfo>().table_name;
+	}
+	return "";
+}
+
+static void CollectNullableBaseTables(LogicalOperator *node, std::set<string> &out, bool &complete, int depth) {
+	if (!node || depth > 64) {
+		complete = false;
+		return;
+	}
+	if (node->type == LogicalOperatorType::LOGICAL_GET) {
+		string t = NullableGetTableName(node->Cast<LogicalGet>());
+		if (t.empty()) {
+			complete = false; // table function / unresolved scan — can't name it
+			return;
+		}
+		out.insert(StringUtil::Lower(SqlUtils::StripTrackedTablePrefix(t, /*strip_delta=*/true)));
+		return;
+	}
+	if (node->type == LogicalOperatorType::LOGICAL_CTE_REF) {
+		complete = false; // CTE body not resolvable here — stay conservative
+		return;
+	}
+	for (auto &child : node->children) {
+		CollectNullableBaseTables(child.get(), out, complete, depth + 1);
+	}
+}
+
+bool BuildLeftJoinNullableSources(const CreateMVPlanFacts &facts, RefreshMetadata::LeftJoinNullableSources &out) {
+	out.tables.clear();
+	out.complete = true;
+	std::set<string> tables;
+	bool found_any = false;
+	vector<LogicalOperator *> stack;
+	if (facts.root) {
+		stack.push_back(facts.root);
+	}
+	while (!stack.empty()) {
+		auto *node = stack.back();
+		stack.pop_back();
+		if ((node->type == LogicalOperatorType::LOGICAL_COMPARISON_JOIN ||
+		     node->type == LogicalOperatorType::LOGICAL_ASOF_JOIN) &&
+		    node->children.size() >= 2) {
+			auto &join = node->Cast<LogicalComparisonJoin>();
+			// Nullable side: right child of LEFT, left child of RIGHT, both of OUTER.
+			if (join.join_type == JoinType::LEFT) {
+				found_any = true;
+				CollectNullableBaseTables(node->children[1].get(), tables, out.complete, 0);
+			} else if (join.join_type == JoinType::RIGHT) {
+				found_any = true;
+				CollectNullableBaseTables(node->children[0].get(), tables, out.complete, 0);
+			} else if (join.join_type == JoinType::OUTER) {
+				found_any = true;
+				CollectNullableBaseTables(node->children[0].get(), tables, out.complete, 0);
+				CollectNullableBaseTables(node->children[1].get(), tables, out.complete, 0);
+			}
+		}
+		for (auto &child : node->children) {
+			stack.push_back(child.get());
+		}
+	}
+	out.tables.assign(tables.begin(), tables.end());
+	return found_any;
 }
 
 struct WindowLineageOp {

--- a/src/core/refresh_metadata.cpp
+++ b/src/core/refresh_metadata.cpp
@@ -973,6 +973,31 @@ string RefreshMetadata::LeftJoinKeyLineageToJson(const ProjectionKeyLineage &lin
 	return ProjectionKeyLineageToJsonWithKind(lineage, "left_join_key");
 }
 
+string RefreshMetadata::LeftJoinNullableSourcesToJson(const LeftJoinNullableSources &src) {
+	string json = "{\"k\":\"left_join_nullable\",\"complete\":" + SqlUtils::JsonQuote(src.complete ? "true" : "false") +
+	              ",\"tables\":[";
+	for (idx_t i = 0; i < src.tables.size(); i++) {
+		if (i > 0) {
+			json += ",";
+		}
+		json += SqlUtils::JsonQuote(src.tables[i]);
+	}
+	json += "]}";
+	return json;
+}
+
+bool RefreshMetadata::GetLeftJoinNullableSources(const string &view_name, LeftJoinNullableSources &out) {
+	string json;
+	if (!ReadRefreshLineageEntry(con, view_name, "left_join_nullable", json)) {
+		return false;
+	}
+	out.tables.clear();
+	out.complete = false;
+	ParseJsonBoolString(json, "complete", out.complete);
+	ExtractJsonStringArray(json, "tables", out.tables);
+	return true;
+}
+
 bool RefreshMetadata::GetFilteredGroupCountAuxMeta(const string &view_name, FilteredGroupCountAuxMeta &out) {
 	auto result = con.Query("SELECT aggregate_decomposition_json FROM " + string(openivm::VIEWS_TABLE) +
 	                        " WHERE view_name = '" + SqlUtils::EscapeValue(view_name) + "'");

--- a/src/include/compile_facts.hpp
+++ b/src/include/compile_facts.hpp
@@ -18,12 +18,30 @@ namespace openivm {
 // `ParseFactsJson` deserialises the JSON object directly into these fields.
 class CompileFacts {
 public:
-	// Reserved for future schema evolution. Current valid value is 1.
-	static constexpr int CURRENT_SCHEMA_VERSION = 1;
+	// Schema evolution: v1 = scalar framing only; v2 = adds nested "universal"
+	// and "batch" objects. Both are accepted by the parser.
+	static constexpr int CURRENT_SCHEMA_VERSION = 2;
 	int schema_version = CURRENT_SCHEMA_VERSION;
 	SqlDialect target_dialect = SqlDialect::DUCKDB; // required when parsed from JSON
 	bool compile_only = false;                      // default false
 	bool force_view_delta_cascade = false;
+
+	// ---- Universal facts (stable for the view's lifetime; from the "universal" object) ----
+	// When true, the compiler emits derived universal facts back to the caller as extra
+	// "derived_fact" output rows (currently the LEFT-JOIN nullable-source set + referenced sources).
+	bool emit_derived_facts = false;
+	// Forward scaffolding — parsed but not yet consumed by emission. See compile_facts plan.
+	vector<string> source_constraints; // e.g. "table:PK(col)", "t:FK(col)->u(col)"
+	vector<string> partitioning;       // e.g. "table:partition(col,...)"
+	vector<string> target_capabilities; // e.g. "MERGE", "DELETION_VECTORS", "ROWID"
+
+	// ---- Per-batch facts (vary each refresh; from the "batch" object) ----
+	// has_batch_facts gates whether planning may trust active_delta_tables/batch_insert_only.
+	// When false (no "batch" object — v1 callers, or v2 omitting it) the compile-only path keeps
+	// the conservative all-sources / insert_only=false defaults, preserving today's behavior.
+	bool has_batch_facts = false;
+	vector<string> active_delta_tables; // prefixed form: openivm_delta_<base>
+	bool batch_insert_only = false;
 
 	// Returns a default-constructed CompileFacts wrapping the given dialect.
 	// Used by native PRAGMA-refresh callers which have no JSON facts — every

--- a/src/include/compile_facts.hpp
+++ b/src/include/compile_facts.hpp
@@ -31,8 +31,8 @@ public:
 	// "derived_fact" output rows (currently the LEFT-JOIN nullable-source set + referenced sources).
 	bool emit_derived_facts = false;
 	// Forward scaffolding — parsed but not yet consumed by emission. See compile_facts plan.
-	vector<string> source_constraints; // e.g. "table:PK(col)", "t:FK(col)->u(col)"
-	vector<string> partitioning;       // e.g. "table:partition(col,...)"
+	vector<string> source_constraints;  // e.g. "table:PK(col)", "t:FK(col)->u(col)"
+	vector<string> partitioning;        // e.g. "table:partition(col,...)"
 	vector<string> target_capabilities; // e.g. "MERGE", "DELETION_VECTORS", "ROWID"
 
 	// ---- Per-batch facts (vary each refresh; from the "batch" object) ----

--- a/src/include/core/ivm_view_classifier.hpp
+++ b/src/include/core/ivm_view_classifier.hpp
@@ -195,6 +195,10 @@ struct DeltaViewModel {
 	// push the affected-key filter into the LEFT JOIN recompute (generic replacement for the former
 	// fact_market_history hardcode). Reuses the projection-key lineage struct with a single identity arm.
 	RefreshMetadata::ProjectionKeyLineage left_join_key_lineage;
+	// Base source tables on the NULL-extended side of the view's LEFT/OUTER joins, extracted from the
+	// plan at create time. Drives the Tier-1 insert-only append fast path: a batch whose active delta
+	// touches none of these cannot cause a NULL->matched flip, so the view delta is purely insert-only.
+	RefreshMetadata::LeftJoinNullableSources left_join_nullable_sources;
 	idx_t root_node = DConstants::INVALID_INDEX;
 	string full_outer_join_cols;
 	GroupRecomputeAffectedMode group_recompute_affected_mode = GroupRecomputeAffectedMode::SOURCE_DELTA;
@@ -206,6 +210,7 @@ struct DeltaViewModel {
 	bool union_distinct_over_agg = false;
 	bool has_projection_lineage = false;
 	bool has_left_join_key_lineage = false;
+	bool has_left_join_nullable = false;
 	bool warn_unsupported_incremental = false;
 	bool warn_unrecognized_pattern = false;
 

--- a/src/include/core/parser_plan_helpers.hpp
+++ b/src/include/core/parser_plan_helpers.hpp
@@ -128,6 +128,11 @@ bool BuildProjectionKeyLineage(const CreateMVPlanFacts &facts, const vector<stri
 // producing a single-arm ProjectionKeyLineage. Returns false (caller falls back to full LEFT JOIN
 // recompute) when the key is derived/multi-source or the source cannot be resolved.
 bool BuildLeftJoinKeyLineage(const CreateMVPlanFacts &facts, RefreshMetadata::ProjectionKeyLineage &out);
+// Collect base source tables on the NULL-extended side of every LEFT/RIGHT/OUTER join in the plan
+// (right child of LEFT, left child of RIGHT, both of OUTER), resolving through subqueries/LATERAL since
+// it walks the logical tree. Sets out.complete=false when a nullable source can't be resolved (e.g. an
+// unresolved CTE ref) so callers stay conservative. Returns true if the plan has any such join.
+bool BuildLeftJoinNullableSources(const CreateMVPlanFacts &facts, RefreshMetadata::LeftJoinNullableSources &out);
 void ResolveAggregateGroupColumnsThroughJoinKeys(const CreateMVPlanFacts &facts, vector<string> &aggregate_columns,
                                                  const vector<string> &output_names);
 string ExtractFullOuterJoinMetadata(const CreateMVPlanFacts &facts);

--- a/src/include/core/refresh_metadata.hpp
+++ b/src/include/core/refresh_metadata.hpp
@@ -272,6 +272,17 @@ public:
 	bool GetLeftJoinKeyLineage(const string &view_name, ProjectionKeyLineage &out);
 	static string LeftJoinKeyLineageToJson(const ProjectionKeyLineage &lineage);
 
+	// Base source tables on the NULL-extended side of the view's LEFT/OUTER joins, extracted from the
+	// plan at create time and persisted as a "left_join_nullable" entry. `complete` is false when any
+	// nullable source could not be resolved (e.g. an unresolved CTE ref) — callers must then treat the
+	// nullable side as potentially-active (conservative). Drives the Tier-1 insert-only append fast path.
+	struct LeftJoinNullableSources {
+		vector<string> tables; // normalized lowercase base names (openivm_data_/delta_ prefixes stripped)
+		bool complete = false;
+	};
+	bool GetLeftJoinNullableSources(const string &view_name, LeftJoinNullableSources &out);
+	static string LeftJoinNullableSourcesToJson(const LeftJoinNullableSources &src);
+
 	struct FilteredGroupCountAuxMeta {
 		string aux_table;
 		string source;

--- a/src/include/upsert/refresh_internal.hpp
+++ b/src/include/upsert/refresh_internal.hpp
@@ -188,7 +188,8 @@ string CompileProjectionRefresh(RefreshMetadata &metadata, const string &view_na
                                 const vector<string> &delta_table_names, const string &data_table,
                                 const string &view_query_sql, const string &delta_ts_filter,
                                 const string &catalog_prefix, bool has_full_outer, bool has_left_join,
-                                bool skip_proj_delete);
+                                bool skip_proj_delete, bool insert_only = false,
+                                const vector<string> &active_delta_table_names = {});
 bool TryBuildDuckLakeProjectionKeyRefresh(RefreshMetadata &metadata, Connection &con, const string &view_name,
                                           const vector<string> &delta_table_names, const string &data_table,
                                           const string &view_query_sql, const string &view_catalog_name,

--- a/src/upsert/refresh_delta_fast_paths.cpp
+++ b/src/upsert/refresh_delta_fast_paths.cpp
@@ -3,9 +3,36 @@
 #include "core/openivm_constants.hpp"
 #include "core/openivm_debug.hpp"
 #include "core/sql_utils.hpp"
+#include "duckdb/common/string_util.hpp"
 #include "duckdb/main/connection.hpp"
 
+#include <unordered_map>
+
 namespace duckdb {
+
+// Canonicalize caller-supplied active-delta names (CompileFacts.active_delta_tables) to the
+// prefixed "openivm_delta_<base>" form the planner uses, by matching on base name against the
+// view's known delta_table_names (case-insensitive). Names matching no known delta table are
+// dropped (logged) — an unknown source must never silently widen the active set.
+static vector<string> NormalizeActiveDeltaNames(const vector<string> &supplied,
+                                                const vector<string> &delta_table_names) {
+	std::unordered_map<string, string> by_base;
+	for (auto &dt : delta_table_names) {
+		by_base[StringUtil::Lower(BaseTableNameFromDeltaKey(dt))] = dt;
+	}
+	vector<string> out;
+	for (auto &name : supplied) {
+		string base = StringUtil::Lower(BaseTableNameFromDeltaKey(name));
+		auto it = by_base.find(base);
+		if (it != by_base.end()) {
+			out.push_back(it->second);
+		} else {
+			OPENIVM_DEBUG_PRINT("[UPSERT] batch fact active_delta '%s' (base '%s') matches no known delta — dropped\n",
+			                    name.c_str(), base.c_str());
+		}
+	}
+	return out;
+}
 
 static bool QueryLooksLikeJoin(const string &view_query_sql, const vector<string> &delta_table_names) {
 	return delta_table_names.size() > 1 || view_query_sql.find("JOIN") != string::npos ||
@@ -272,12 +299,32 @@ DeltaFastPathFlags ResolveDeltaFastPathFlags(ClientContext &context, RefreshMeta
 	(void)cross_system;
 	if (facts && facts->compile_only) {
 		DeltaFastPathFlags flags;
+		if (facts->has_batch_facts) {
+			// Caller (openivm-spark) supplied this batch's delta activity. Trust it instead of probing
+			// live delta tables (which we cannot read in compile-only mode). Absence of batch facts keeps
+			// the conservative path below; supplying them can only ENABLE a fast path, never disable a guard.
+			flags.active_delta_table_names = NormalizeActiveDeltaNames(facts->active_delta_tables, delta_table_names);
+			flags.insert_only = facts->batch_insert_only;
+			flags.skip_agg_delete = flags.insert_only;
+			flags.skip_proj_delete = flags.insert_only;
+			flags.minmax_incremental = flags.insert_only;
+			if (!SqlUtils::GetBoolSetting(context, "openivm_skip_aggregate_delete", true)) {
+				flags.skip_agg_delete = false;
+			}
+			if (!SqlUtils::GetBoolSetting(context, "openivm_skip_projection_delete", true)) {
+				flags.skip_proj_delete = false;
+			}
+			if (!SqlUtils::GetBoolSetting(context, "openivm_minmax_incremental", true)) {
+				flags.minmax_incremental = false;
+			}
+			OPENIVM_DEBUG_PRINT("[UPSERT] compile_only=true WITH batch facts: insert_only=%d active_sources=%zu\n",
+			                    flags.insert_only, flags.active_delta_table_names.size());
+			return flags;
+		}
+		// No batch facts: conservative (cannot probe live deltas in compile-only mode). The LEFT-JOIN
+		// Tier-1 insert-only append does not fire here — preserves pre-batch-facts behavior.
 		flags.active_delta_table_names = delta_table_names;
-		// NOTE: in compile-only mode (openivm-spark) we cannot probe live delta tables, so insert_only
-		// stays false and the active set is ALL sources. The LEFT-JOIN Tier-1 insert-only append
-		// therefore never fires here. To enable it on Spark, openivm-spark must pass the per-batch delta
-		// activity (which sources changed + insert-only) through CompileFacts so these can be set.
-		OPENIVM_DEBUG_PRINT("[UPSERT] compile_only=true: disabling local delta fast paths, active_sources=%zu\n",
+		OPENIVM_DEBUG_PRINT("[UPSERT] compile_only=true NO batch facts: conservative, active_sources=%zu\n",
 		                    flags.active_delta_table_names.size());
 		return flags;
 	}

--- a/src/upsert/refresh_delta_fast_paths.cpp
+++ b/src/upsert/refresh_delta_fast_paths.cpp
@@ -273,6 +273,10 @@ DeltaFastPathFlags ResolveDeltaFastPathFlags(ClientContext &context, RefreshMeta
 	if (facts && facts->compile_only) {
 		DeltaFastPathFlags flags;
 		flags.active_delta_table_names = delta_table_names;
+		// NOTE: in compile-only mode (openivm-spark) we cannot probe live delta tables, so insert_only
+		// stays false and the active set is ALL sources. The LEFT-JOIN Tier-1 insert-only append
+		// therefore never fires here. To enable it on Spark, openivm-spark must pass the per-batch delta
+		// activity (which sources changed + insert-only) through CompileFacts so these can be set.
 		OPENIVM_DEBUG_PRINT("[UPSERT] compile_only=true: disabling local delta fast paths, active_sources=%zu\n",
 		                    flags.active_delta_table_names.size());
 		return flags;

--- a/src/upsert/refresh_helpers.cpp
+++ b/src/upsert/refresh_helpers.cpp
@@ -16,6 +16,7 @@
 #include <algorithm>
 #include <cctype>
 #include <cstring>
+#include <set>
 
 namespace duckdb {
 
@@ -778,6 +779,44 @@ static string TryBuildLeftJoinAffectedPushdown(RefreshMetadata &metadata, const 
 	                                        delete_match, affected + "openivm_lj." + lk + ")", affected_cte);
 }
 
+static string NormalizeTableToken(string tok) {
+	while (!tok.empty() && (tok.front() == '"' || tok.front() == '`' || tok.front() == '\'')) {
+		tok.erase(tok.begin());
+	}
+	while (!tok.empty() && (tok.back() == '"' || tok.back() == '`' || tok.back() == '\'')) {
+		tok.pop_back();
+	}
+	tok = SqlUtils::StripTrackedTablePrefix(tok, /*strip_delta=*/true); // last dotted part + strip prefixes
+	return StringUtil::Lower(tok);
+}
+
+// Q2/D2 guard: true iff this batch's active delta touches ONLY preserved-side sources (no
+// LEFT-JOIN nullable table changed). Then no NULL->matched flip is possible, the view delta
+// is purely insert-only, and it can be appended directly (Tier 1). Otherwise we fall back to
+// the affected-key recompute (Tier 2), which stays correct for arbitrary batches.
+//
+// The nullable-source set is extracted structurally from the plan at create time
+// (BuildLeftJoinNullableSources) and read here via metadata — robust to subqueries / LATERAL /
+// aliasing / MV-on-MV, unlike a textual scan of the SQL. We require `complete` so any source
+// the plan walk could not resolve forces the conservative recompute path.
+static bool LeftJoinDeltaNullableQuiet(RefreshMetadata &metadata, const string &view_name,
+                                       const vector<string> &active_delta_table_names) {
+	if (active_delta_table_names.empty()) {
+		return false; // unknown active set — take the safe recompute path
+	}
+	RefreshMetadata::LeftJoinNullableSources nullable;
+	if (!metadata.GetLeftJoinNullableSources(view_name, nullable) || !nullable.complete || nullable.tables.empty()) {
+		return false; // no structured nullable-source info (or incomplete) — recompute
+	}
+	std::set<string> nullable_set(nullable.tables.begin(), nullable.tables.end());
+	for (auto &dt : active_delta_table_names) {
+		if (nullable_set.count(NormalizeTableToken(BaseTableNameFromDeltaKey(dt)))) {
+			return false; // a nullable-side source changed — flip possible
+		}
+	}
+	return true;
+}
+
 static string BuildLeftJoinProjectionRefresh(RefreshMetadata &metadata, const string &view_name,
                                              const string &data_table, const string &view_query_sql,
                                              const string &delta_ts_filter, const string &catalog_prefix) {
@@ -799,12 +838,27 @@ string CompileProjectionRefresh(RefreshMetadata &metadata, const string &view_na
                                 const vector<string> &delta_table_names, const string &data_table,
                                 const string &view_query_sql, const string &delta_ts_filter,
                                 const string &catalog_prefix, bool has_full_outer, bool has_left_join,
-                                bool skip_proj_delete) {
+                                bool skip_proj_delete, bool insert_only,
+                                const vector<string> &active_delta_table_names) {
 	if (has_full_outer) {
 		return BuildFullOuterProjectionRefresh(metadata, view_name, delta_table_names, data_table, view_query_sql,
 		                                       delta_ts_filter, catalog_prefix);
 	}
 	if (has_left_join) {
+		// Tier 1 (Q2/D2 fast path): when the batch is insert-only (no base deletes) AND the
+		// active delta touches only preserved-side sources (no LEFT-JOIN nullable table
+		// changed), no NULL->matched flip is possible, so the view delta is purely positive.
+		// Append it directly instead of deleting affected keys + recomputing their full
+		// (fan-out-amplified) history. Provably exact: positive-only delta, bag table.
+		if (insert_only && LeftJoinDeltaNullableQuiet(metadata, view_name, active_delta_table_names)) {
+			OPENIVM_DEBUG_PRINT("[UPSERT] LEFT JOIN Tier1 insert-only append for %s (nullable side quiet)\n",
+			                    view_name.c_str());
+			return CompileProjectionsFilters(view_name, column_names, delta_ts_filter, catalog_prefix,
+			                                 /*insert_only=*/true);
+		}
+		// Tier 2: nullable side changed (or batch has deletes / active set unknown) — keep the
+		// affected-key delete + recompute, which stays correct for arbitrary insert/delete
+		// batches (modulo the pre-existing NULL->matched flip retraction gap shared with baseline).
 		return BuildLeftJoinProjectionRefresh(metadata, view_name, data_table, view_query_sql, delta_ts_filter,
 		                                      catalog_prefix);
 	}

--- a/src/upsert/refresh_sql.cpp
+++ b/src/upsert/refresh_sql.cpp
@@ -753,7 +753,8 @@ string GenerateRefreshSQL(ClientContext &context, const string &view_catalog_nam
 			} else {
 				upsert_query = CompileProjectionRefresh(
 				    metadata, view_name, column_names, delta_table_names, data_table, view_query_sql, delta_ts_filter,
-				    internal_catalog_prefix, has_full_outer, has_left_join, skip_proj_delete);
+				    internal_catalog_prefix, has_full_outer, has_left_join, skip_proj_delete, insert_only,
+				    fast_paths.active_delta_table_names);
 			}
 			break;
 		}

--- a/test/sql/compile_facts_batch.test
+++ b/test/sql/compile_facts_batch.test
@@ -1,0 +1,105 @@
+# name: test/sql/compile_facts_batch.test
+# description: openivm_compile_with_facts per-batch facts drive the LEFT-JOIN Tier-1 insert-only append (openivm-spark compile-only path), plus derived-fact output enrichment.
+# group: [sql]
+
+require openivm
+
+statement ok
+SET openivm_files_path='__TEST_DIR__';
+
+statement ok
+CREATE TABLE sec(sym VARCHAR, ckey INT);
+
+statement ok
+CREATE TABLE daily(sym VARCHAR, px INT);
+
+statement ok
+CREATE TABLE fin(ckey INT, val INT);
+
+statement ok
+INSERT INTO sec VALUES ('A',10),('B',20);
+
+statement ok
+INSERT INTO fin VALUES (10,1),(10,2),(20,5);
+
+statement ok
+INSERT INTO daily VALUES ('A',100),('B',200);
+
+# fact_market_history shape: preserved (daily JOIN sec) LEFT JOIN fin (nullable, no output column).
+statement ok
+CREATE MATERIALIZED VIEW mh AS
+    SELECT sec.ckey, daily.sym, daily.px
+    FROM daily JOIN sec ON daily.sym=sec.sym
+    LEFT JOIN fin f ON f.ckey=sec.ckey;
+
+# Batch facts: only the preserved-side source (daily) is active + insert-only -> Tier-1 append
+# (generate_series over the view delta; no affected-key recompute).
+query I
+SELECT bool_or(contains(sql,'generate_series')) AND NOT bool_or(contains(sql,'openivm_affected'))
+FROM openivm_compile_with_facts('mh',
+  '{"schema_version":2,"target_dialect":"duckdb","compile_only":true,"batch":{"active_delta_tables":["openivm_delta_daily"],"insert_only":true}}')
+WHERE stmt_kind='data';
+----
+true
+
+# Batch facts: the nullable source (fin) is active -> a NULL->matched flip is possible ->
+# fall back to the affected-key recompute (Tier-2).
+query I
+SELECT bool_or(contains(sql,'openivm_affected'))
+FROM openivm_compile_with_facts('mh',
+  '{"schema_version":2,"target_dialect":"duckdb","compile_only":true,"batch":{"active_delta_tables":["openivm_delta_fin"],"insert_only":true}}')
+WHERE stmt_kind='data';
+----
+true
+
+# Bare base names (no openivm_delta_ prefix) are normalized too: daily-only still fires Tier-1.
+query I
+SELECT bool_or(contains(sql,'generate_series')) AND NOT bool_or(contains(sql,'openivm_affected'))
+FROM openivm_compile_with_facts('mh',
+  '{"schema_version":2,"target_dialect":"duckdb","compile_only":true,"batch":{"active_delta_tables":["daily"],"insert_only":true}}')
+WHERE stmt_kind='data';
+----
+true
+
+# An unknown source name is dropped (never widens the active set): daily + bogus still Tier-1.
+query I
+SELECT bool_or(contains(sql,'generate_series')) AND NOT bool_or(contains(sql,'openivm_affected'))
+FROM openivm_compile_with_facts('mh',
+  '{"schema_version":2,"target_dialect":"duckdb","compile_only":true,"batch":{"active_delta_tables":["openivm_delta_daily","openivm_delta_nonexistent"],"insert_only":true}}')
+WHERE stmt_kind='data';
+----
+true
+
+# insert_only=false (e.g. batch had deletes) -> not insert-only-safe -> recompute even on daily-only.
+query I
+SELECT bool_or(contains(sql,'openivm_affected'))
+FROM openivm_compile_with_facts('mh',
+  '{"schema_version":2,"target_dialect":"duckdb","compile_only":true,"batch":{"active_delta_tables":["openivm_delta_daily"],"insert_only":false}}')
+WHERE stmt_kind='data';
+----
+true
+
+# No batch facts (v1 caller) -> conservative recompute (backward compatible).
+query I
+SELECT bool_or(contains(sql,'openivm_affected'))
+FROM openivm_compile_with_facts('mh', '{"target_dialect":"duckdb","compile_only":true}')
+WHERE stmt_kind='data';
+----
+true
+
+# Output enrichment: emit_derived_facts returns the LEFT-join nullable-source set.
+query I
+SELECT contains(sql,'"nullable_sources":["fin"]')
+FROM openivm_compile_with_facts('mh',
+  '{"schema_version":2,"target_dialect":"duckdb","compile_only":true,"universal":{"emit_derived_facts":true}}')
+WHERE stmt_kind='derived_fact';
+----
+true
+
+# Without emit_derived_facts: no derived_fact row.
+query I
+SELECT count(*)
+FROM openivm_compile_with_facts('mh', '{"target_dialect":"duckdb","compile_only":true}')
+WHERE stmt_kind='derived_fact';
+----
+0

--- a/test/sql/left_join_affected_pushdown.test
+++ b/test/sql/left_join_affected_pushdown.test
@@ -223,3 +223,146 @@ SELECT COUNT(*) FROM (
 );
 ----
 0
+
+# ============================================================
+# Tier-1 insert-only append fast path (Q2: nullable side quiet).
+# fact_market_history shape: preserved side (daily JOIN sec) LEFT JOIN fin where the
+# LEFT JOIN contributes NO output column (pure fan-out / existence multiplier).
+# A delta on the PRESERVED side only cannot cause a NULL->matched flip, so the view
+# delta is purely insert-only and is appended directly (no affected-key recompute).
+# ============================================================
+statement ok
+CREATE TABLE t1_sec(sym VARCHAR, ckey INT);
+
+statement ok
+CREATE TABLE t1_daily(sym VARCHAR, px INT);
+
+statement ok
+CREATE TABLE t1_fin(ckey INT, val INT);
+
+statement ok
+INSERT INTO t1_sec VALUES ('A',10),('B',20),('C',30);
+
+# ckey 10 has 2 financial periods (fan-out x2), 20 has 1, 30 has none (NULL-extended)
+statement ok
+INSERT INTO t1_fin VALUES (10,1),(10,2),(20,5);
+
+statement ok
+INSERT INTO t1_daily VALUES ('A',100),('B',200),('C',300);
+
+statement ok
+CREATE MATERIALIZED VIEW t1_mh AS
+    SELECT s.ckey, d.sym, d.px
+    FROM t1_daily d JOIN t1_sec s ON d.sym=s.sym
+    LEFT JOIN t1_fin f ON f.ckey=s.ckey;
+
+# Preserved-side-only append -> Tier 1: emitted apply is a direct INSERT append
+# (generate_series over the view delta), NOT a delete-affected + recompute.
+statement ok
+INSERT INTO t1_daily VALUES ('A',101),('B',201),('C',301);
+
+statement ok
+PRAGMA refresh('t1_mh');
+
+query I
+SELECT contains(content, 'generate_series')
+   AND NOT contains(content, 'openivm_affected')
+FROM read_text('__TEST_DIR__/openivm_upsert_queries_t1_mh.sql');
+----
+true
+
+# Bag-exact vs full recompute (fan-out multiplicity preserved).
+query I
+SELECT COUNT(*) FROM (
+  SELECT s.ckey, d.sym, d.px FROM t1_daily d JOIN t1_sec s ON d.sym=s.sym LEFT JOIN t1_fin f ON f.ckey=s.ckey
+  EXCEPT ALL SELECT * FROM t1_mh);
+----
+0
+
+query I
+SELECT COUNT(*) FROM (
+  SELECT * FROM t1_mh
+  EXCEPT ALL SELECT s.ckey, d.sym, d.px FROM t1_daily d JOIN t1_sec s ON d.sym=s.sym LEFT JOIN t1_fin f ON f.ckey=s.ckey);
+----
+0
+
+# Nullable-side (fin) change must NOT take the fast path — a NULL->matched flip is
+# possible, so it falls back to the affected-key recompute. Correctness still holds.
+statement ok
+INSERT INTO t1_fin VALUES (20,6);
+
+statement ok
+PRAGMA refresh('t1_mh');
+
+query I
+SELECT contains(content, 'openivm_affected')
+FROM read_text('__TEST_DIR__/openivm_upsert_queries_t1_mh.sql');
+----
+true
+
+query I
+SELECT COUNT(*) FROM (
+  SELECT s.ckey, d.sym, d.px FROM t1_daily d JOIN t1_sec s ON d.sym=s.sym LEFT JOIN t1_fin f ON f.ckey=s.ckey
+  EXCEPT ALL SELECT * FROM t1_mh);
+----
+0
+
+query I
+SELECT COUNT(*) FROM (
+  SELECT * FROM t1_mh
+  EXCEPT ALL SELECT s.ckey, d.sym, d.px FROM t1_daily d JOIN t1_sec s ON d.sym=s.sym LEFT JOIN t1_fin f ON f.ckey=s.ckey);
+----
+0
+
+# Structural nullable-source detection sees through a subquery RHS (a textual scan can't):
+# preserved-side delta still takes Tier 1, nullable-side delta inside the subquery recomputes.
+statement ok
+CREATE TABLE t2_sec(sym VARCHAR, ckey INT);
+
+statement ok
+CREATE TABLE t2_daily(sym VARCHAR, px INT);
+
+statement ok
+CREATE TABLE t2_fin(ckey INT, val INT);
+
+statement ok
+INSERT INTO t2_sec VALUES ('A',10),('B',20);
+
+statement ok
+INSERT INTO t2_fin VALUES (10,1),(10,2),(20,5);
+
+statement ok
+INSERT INTO t2_daily VALUES ('A',100),('B',200);
+
+statement ok
+CREATE MATERIALIZED VIEW t2_mh AS
+    SELECT s.ckey, d.sym, d.px
+    FROM t2_daily d JOIN t2_sec s ON d.sym=s.sym
+    LEFT JOIN (SELECT ckey FROM t2_fin) f ON f.ckey=s.ckey;
+
+statement ok
+INSERT INTO t2_daily VALUES ('A',101);
+
+statement ok
+PRAGMA refresh('t2_mh');
+
+# Tier 1 even though the nullable side is a subquery (plan walk resolved t2_fin).
+query I
+SELECT contains(content, 'generate_series') AND NOT contains(content, 'openivm_affected')
+FROM read_text('__TEST_DIR__/openivm_upsert_queries_t2_mh.sql');
+----
+true
+
+query I
+SELECT COUNT(*) FROM (
+  SELECT s.ckey, d.sym, d.px FROM t2_daily d JOIN t2_sec s ON d.sym=s.sym LEFT JOIN (SELECT ckey FROM t2_fin) f ON f.ckey=s.ckey
+  EXCEPT ALL SELECT * FROM t2_mh);
+----
+0
+
+query I
+SELECT COUNT(*) FROM (
+  SELECT * FROM t2_mh
+  EXCEPT ALL SELECT s.ckey, d.sym, d.px FROM t2_daily d JOIN t2_sec s ON d.sym=s.sym LEFT JOIN (SELECT ckey FROM t2_fin) f ON f.ckey=s.ckey);
+----
+0


### PR DESCRIPTION
Fast-forward of `main` (2 commits, clean linear).

**1. LEFT JOIN SIMPLE_PROJECTION insert-only append** (`b1b2113a`)
When a SIMPLE_PROJECTION view has a LEFT/OUTER join and the batch's active delta touches only preserved-side sources (no NULL→matched flip), append the precomputed view-delta instead of delete-affected + recompute. Nullable-source set extracted structurally from the plan at MV-creation (`BuildLeftJoinNullableSources`) and persisted in lineage. Full suite green; new `test/sql/left_join_affected_pushdown.test` cases.

**2. CompileFacts per-batch facts + universal scaffolding + derived-fact output** (`3c8aa963`)
Schema-v2 `openivm_compile_with_facts` (nested `universal`/`batch`, backward compatible). `batch.active_delta_tables` + `insert_only` let a compile-only caller (openivm-spark) drive the fast path; `emit_derived_facts` returns the nullable-source set. `test/sql/compile_facts_batch.test`.

Drives the openivm-spark per-batch CompileFacts work (ila/openivm-spark + mdrakiburrahman/openivm-spark#9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)