### PR TITLE
Remove legacy refresh type 10

### DIFF
--- a/docs/codebase-audit-2026-07-22.md
+++ b/docs/codebase-audit-2026-07-22.md
@@ -76,9 +76,9 @@ maintenance path. A bug must not be hidden by weakening a test or silently chang
   physical schema requires the original SQL identifier. Quoted names containing punctuation can fail during MV creation.
 - [ ] **Classify only after required lineage is valid.** Window lineage can demote a finalized model to `FULL_REFRESH` after
   node maintenance and update semantics have already been derived, leaving contradictory model state.
-- [ ] **Finish or reverse the `CURRENT_DIFF_RECOMPUTE` removal coherently.** Deterministic SAMPLE, POSITIONAL, and ASOF shapes
-  are demoted to unconditional full refresh while stale nonlocal strategies, documentation, and benchmark paths remain.
-  Preserve a typed affected/current-diff recompute path where correctness permits it; delete truly dead strategies.
+- [x] **Remove deprecated refresh type value 10.** Deterministic SAMPLE, POSITIONAL, and ASOF shapes
+  demote to full refresh. The separate current-diff affected-key mode remains part of group recompute; it is not a refresh
+  type.
 - [ ] **Strip computed top-k wrappers from stored aggregate state.** CREATE only moves a root `TOP_N` or
   `LIMIT -> ORDER_BY` into the user-facing view. Plans such as
   `PROJECTION -> TOP_N -> PROJECTION -> AGGREGATE` therefore initialize a limited backing table, while refresh strips the

--- a/src/core/refresh_metadata.cpp
+++ b/src/core/refresh_metadata.cpp
@@ -41,9 +41,6 @@ RefreshType RefreshMetadata::GetViewType(const string &view_name) {
 		throw ParserException("Materialized view '%s' does not exist in IVM metadata.", view_name);
 	}
 	auto raw_type = result->GetValue(0, 0).GetValue<int8_t>();
-	if (raw_type == static_cast<int8_t>(openivm::LEGACY_CURRENT_DIFF_RECOMPUTE_TYPE)) {
-		return RefreshType::FULL_REFRESH;
-	}
 	return static_cast<RefreshType>(raw_type);
 }
 

--- a/src/include/core/openivm_constants.hpp
+++ b/src/include/core/openivm_constants.hpp
@@ -84,8 +84,6 @@ constexpr const char *DISABLED_OPTIMIZERS = TEMPLATE_DATA_DEPENDENT_OPTIMIZERS;
 // DELIM joins to eliminate. Pure robustness guard — not flag-gated.
 constexpr const char *REFRESH_DISABLED_OPTIMIZERS = "deliminator";
 
-constexpr uint8_t LEGACY_CURRENT_DIFF_RECOMPUTE_TYPE = 10;
-
 } // namespace openivm
 
 enum class RefreshType : uint8_t {

--- a/test/sql/compile_refresh.test
+++ b/test/sql/compile_refresh.test
@@ -224,8 +224,6 @@ WHERE stmt_kind = 'data';
 ----
 1
 
-# CURRENT_DIFF_RECOMPUTE coverage for ASOF views lives in compile_refresh_asof.test.
-
 # ==========================================
 # Test 6: a caller-proven insert-only batch enables the MIN/MAX MERGE
 # template, including a scalar output derived from the final aggregate state.

--- a/test/sql/nonlocal_operator_recompute.test
+++ b/test/sql/nonlocal_operator_recompute.test
@@ -95,59 +95,6 @@ SELECT type FROM openivm_views WHERE view_name = 'mv_oprec_sample_volatile';
 ----
 3
 
-# Persisted legacy CURRENT_DIFF_RECOMPUTE metadata (type 10) maps to the
-# current full-refresh strategy during refresh.
-
-statement ok
-CREATE TABLE oprec_legacy_type10 (id INT, grp INT, v INT);
-
-statement ok
-INSERT INTO oprec_legacy_type10 VALUES
-    (1, 1, 10),
-    (2, 1, 20),
-    (3, 2, 30),
-    (4, 2, 40);
-
-statement ok
-CREATE MATERIALIZED VIEW mv_oprec_legacy_type10 AS
-    SELECT id, grp, v
-    FROM oprec_legacy_type10 USING SAMPLE reservoir(3 ROWS) REPEATABLE (31);
-
-statement ok
-UPDATE openivm_views SET type = 10 WHERE view_name = 'mv_oprec_legacy_type10';
-
-statement ok
-INSERT INTO oprec_legacy_type10 VALUES (5, 3, 50);
-
-statement ok
-DELETE FROM oprec_legacy_type10 WHERE id = 2;
-
-statement ok
-UPDATE oprec_legacy_type10 SET v = 15 WHERE id = 1;
-
-statement ok
-PRAGMA refresh('mv_oprec_legacy_type10');
-
-query I
-SELECT count(*) FROM (
-    SELECT id, grp, v
-    FROM oprec_legacy_type10 USING SAMPLE reservoir(3 ROWS) REPEATABLE (31)
-    EXCEPT ALL
-    SELECT id, grp, v FROM mv_oprec_legacy_type10
-);
-----
-0
-
-query I
-SELECT count(*) FROM (
-    SELECT id, grp, v FROM mv_oprec_legacy_type10
-    EXCEPT ALL
-    SELECT id, grp, v
-    FROM oprec_legacy_type10 USING SAMPLE reservoir(3 ROWS) REPEATABLE (31)
-);
-----
-0
-
 # ==========================================
 # POSITIONAL JOIN falls back to full refresh
 # ==========================================


### PR DESCRIPTION
Removes the deprecated refresh-type-10 compatibility constant, metadata fallback, and migration-only regression coverage. The live current-diff affected-key mode used by group recompute remains unchanged.\n\nValidation: git diff --check; no remaining refresh-type-10 or CURRENT_DIFF_RECOMPUTE references under src/test/docs.