### PR TITLE
Optimize DuckLake ordered window refreshes

### DIFF
--- a/src/core/incremental_checker.cpp
+++ b/src/core/incremental_checker.cpp
@@ -46,6 +46,28 @@ static string OrderByColumnName(const Expression &expr) {
 	return string();
 }
 
+static bool WindowColumn(const Expression &expr, string &name, idx_t &column_index) {
+	if (expr.type != ExpressionType::BOUND_COLUMN_REF) {
+		return false;
+	}
+	auto &column = expr.Cast<BoundColumnRefExpression>();
+	name = column.alias.empty() ? column.GetName() : column.alias;
+	column_index = column.binding.column_index;
+	return !name.empty();
+}
+
+static bool SameWindowColumns(const vector<string> &left, const vector<string> &right) {
+	if (left.size() != right.size()) {
+		return false;
+	}
+	for (idx_t i = 0; i < left.size(); i++) {
+		if (!StringUtil::CIEquals(left[i], right[i])) {
+			return false;
+		}
+	}
+	return true;
+}
+
 /// Populate top_k_order_columns / top_k_order_desc from a vector<BoundOrderByNode>.
 /// Returns false if any entry is non-column-ref (caller should mark incremental_compatible=false).
 static bool ExtractOrderBy(const vector<BoundOrderByNode> &orders, PlanAnalysis &result) {
@@ -357,23 +379,24 @@ static void AnalyzeNode(LogicalOperator *node, PlanAnalysis &result) {
 			result.incremental_compatible = false;
 			result.found_volatile_expression = true;
 		}
-		// Extract PARTITION BY column names from ALL window expressions.
-		// Different window functions may use different PARTITION BY clauses —
-		// collect the union of all partition columns so any change triggers recompute.
+		// Extract PARTITION BY column names from ALL window expressions. Also retain
+		// a common simple PARTITION BY + ORDER BY key when every window agrees. The
+		// latter lets DuckLake pair old/new row occurrences without assuming that the
+		// key is unique; differing or computed window keys keep the existing
+		// partition-recompute path.
 		for (auto &expr : window.expressions) {
 			if (expr->expression_class == ExpressionClass::BOUND_WINDOW) {
 				auto &win_expr = expr->Cast<BoundWindowExpression>();
+				vector<string> current_partitions;
+				vector<string> current_orders;
 				for (auto &part : win_expr.partitions) {
 					string col_name;
 					idx_t col_index = DConstants::INVALID_INDEX;
-					if (part->type == ExpressionType::BOUND_COLUMN_REF) {
-						auto &bcr = part->Cast<BoundColumnRefExpression>();
-						col_name = bcr.alias;
-						col_index = bcr.binding.column_index;
-					}
-					if (col_name.empty()) {
+					if (!WindowColumn(*part, col_name, col_index)) {
+						result.window_row_key_compatible = false;
 						col_name = part->GetName();
 					}
+					current_partitions.push_back(col_name);
 					// Avoid duplicates
 					bool found = false;
 					for (auto &existing : result.window_partition_columns) {
@@ -386,6 +409,30 @@ static void AnalyzeNode(LogicalOperator *node, PlanAnalysis &result) {
 						result.window_partition_columns.push_back(col_name);
 						result.window_partition_column_indexes.push_back(col_index);
 					}
+				}
+				for (auto &order : win_expr.orders) {
+					string col_name;
+					idx_t col_index = DConstants::INVALID_INDEX;
+					if (!WindowColumn(*order.expression, col_name, col_index)) {
+						result.window_row_key_compatible = false;
+						break;
+					}
+					current_orders.push_back(col_name);
+				}
+				if (current_partitions.empty() || current_orders.empty()) {
+					result.window_row_key_compatible = false;
+				}
+				if (result.window_row_key_compatible) {
+					if (result.window_order_columns.empty()) {
+						result.window_order_columns = current_orders;
+					} else if (!SameWindowColumns(result.window_order_columns, current_orders) ||
+					           !SameWindowColumns(result.window_partition_columns, current_partitions)) {
+						result.window_row_key_compatible = false;
+						result.window_order_columns.clear();
+					}
+				}
+				if (!result.window_row_key_compatible) {
+					result.window_order_columns.clear();
 				}
 			}
 		}

--- a/src/core/ivm_view_classifier.cpp
+++ b/src/core/ivm_view_classifier.cpp
@@ -932,8 +932,13 @@ DeltaViewModel BuildDeltaViewModel(const DeltaViewModelInput &input) {
 	model.aggregate_types = analysis.aggregate_types;
 	model.window_partition_columns = analysis.window_partition_columns;
 	ResolveWindowPartitionOutputNames(facts, model.window_partition_columns, output_names);
+	if (analysis.window_row_key_compatible) {
+		model.window_order_columns = analysis.window_order_columns;
+		ResolveWindowPartitionOutputNames(facts, model.window_order_columns, output_names);
+	}
 	if (!input.keep_window_join_partitions) {
 		model.window_partition_columns.clear();
+		model.window_order_columns.clear();
 	}
 
 	model.has_minmax_metadata = analysis.found_minmax || analysis.found_count_distinct || analysis.found_list;

--- a/src/core/parser.cpp
+++ b/src/core/parser.cpp
@@ -975,6 +975,7 @@ MaterializedViewParserExtension::PlanFunction(ParserExtensionInfo *info, ClientC
 	auto aggregate_columns = std::move(view_model.group_columns);
 	auto aggregate_types = std::move(view_model.aggregate_types);
 	auto window_partition_columns = std::move(view_model.window_partition_columns);
+	auto window_order_columns = std::move(view_model.window_order_columns);
 	bool has_minmax_metadata = view_model.has_minmax_metadata;
 	auto group_recompute_affected_mode = view_model.group_recompute_affected_mode;
 	auto group_recompute_source_occurrences = BuildGroupRecomputeSourceOccurrences(facts);
@@ -1105,6 +1106,7 @@ MaterializedViewParserExtension::PlanFunction(ParserExtensionInfo *info, ClientC
 	string refresh_val = parse_data_ref.refresh_interval > 0 ? to_string(parse_data_ref.refresh_interval) : "null";
 	auto &cols_to_store = analysis.found_window ? window_partition_columns : aggregate_columns;
 	string group_cols_val = SqlCsvLiteralOrNull(cols_to_store);
+	string window_order_cols_val = SqlCsvLiteralOrNull(window_order_columns);
 	string agg_types_val = SqlCsvLiteralOrNull(aggregate_types);
 	string having_val = (having_predicate.empty() || stored_query_retains_having)
 	                        ? "null"
@@ -1128,7 +1130,7 @@ MaterializedViewParserExtension::PlanFunction(ParserExtensionInfo *info, ClientC
 	    "insert or replace into " + string(openivm::VIEWS_TABLE) +
 	    " (view_name, view_catalog, view_schema, sql_string, type, has_minmax, has_left_join, "
 	    "has_join, last_update, "
-	    "refresh_interval, refresh_in_progress, group_columns, aggregate_types, "
+	    "refresh_interval, refresh_in_progress, group_columns, window_order_columns, aggregate_types, "
 	    "having_predicate, group_recompute_affected_mode, "
 	    "group_recompute_source_occurrences_json, has_full_outer, "
 	    "full_outer_join_cols) values ('" +
@@ -1136,9 +1138,10 @@ MaterializedViewParserExtension::PlanFunction(ParserExtensionInfo *info, ClientC
 	    SqlUtils::EscapeSingleQuotes(view_target_schema) + "', '" + SqlUtils::EscapeSingleQuotes(view_query) + "', " +
 	    to_string((int)refresh_type) + ", " + (has_minmax_metadata ? "true" : "false") + ", " +
 	    (analysis.found_left_join ? "true" : "false") + ", " + (analysis.found_join ? "true" : "false") + ", " +
-	    string(openivm::UTC_NOW_SQL) + ", " + refresh_val + ", false, " + group_cols_val + ", " + agg_types_val + ", " +
-	    having_val + ", " + group_recompute_mode_val + ", " + group_recompute_source_occurrences_val + ", " +
-	    (analysis.found_full_outer ? "true" : "false") + ", " + full_outer_join_cols_val + ")");
+	    string(openivm::UTC_NOW_SQL) + ", " + refresh_val + ", false, " + group_cols_val + ", " +
+	    window_order_cols_val + ", " + agg_types_val + ", " + having_val + ", " + group_recompute_mode_val + ", " +
+	    group_recompute_source_occurrences_val + ", " + (analysis.found_full_outer ? "true" : "false") + ", " +
+	    full_outer_join_cols_val + ")");
 
 	if (!lineage_json.empty()) {
 		aux_metadata_ddl.push_back(BuildUpdateViewJsonSQL("lineage_json", lineage_json, view_name));

--- a/src/core/parser_create_mv_helpers.cpp
+++ b/src/core/parser_create_mv_helpers.cpp
@@ -41,6 +41,7 @@ void AppendCreateMVSystemTablesDDL(vector<string> &ddl, const string &view_name,
 	              " last_update timestamp, refresh_interval bigint default null,"
 	              " refresh_in_progress boolean default false,"
 	              " group_columns varchar default null,"
+	              " window_order_columns varchar default null,"
 	              " aggregate_types varchar default null,"
 	              " derived_aggregate_outputs_json varchar default null,"
 	              " having_predicate varchar default null,"
@@ -73,6 +74,7 @@ void AppendCreateMVSystemTablesDDL(vector<string> &ddl, const string &view_name,
 	AddColumnIfNotExists(ddl, openivm::VIEWS_TABLE, "derived_aggregate_outputs_json varchar default null");
 	AddColumnIfNotExists(ddl, openivm::VIEWS_TABLE, "view_catalog varchar default null");
 	AddColumnIfNotExists(ddl, openivm::VIEWS_TABLE, "view_schema varchar default null");
+	AddColumnIfNotExists(ddl, openivm::VIEWS_TABLE, "window_order_columns varchar default null");
 	if (!is_replace) {
 		string escaped_view_name = SqlUtils::EscapeSingleQuotes(view_name);
 		string escaped_data_table = SqlUtils::EscapeSingleQuotes(IncrementalTableNames::DataTableName(view_name));

--- a/src/core/refresh_metadata.cpp
+++ b/src/core/refresh_metadata.cpp
@@ -355,6 +355,23 @@ vector<string> RefreshMetadata::GetGroupColumns(const string &view_name) {
 	return cols;
 }
 
+vector<string> RefreshMetadata::GetWindowOrderColumns(const string &view_name) {
+	auto result = con.Query("SELECT window_order_columns FROM " + string(openivm::VIEWS_TABLE) +
+	                        " WHERE view_name = '" + SqlUtils::EscapeValue(view_name) + "'");
+	vector<string> cols;
+	if (result->HasError() || result->RowCount() == 0 || result->GetValue(0, 0).IsNull()) {
+		return cols;
+	}
+	std::istringstream ss(result->GetValue(0, 0).ToString());
+	string token;
+	while (std::getline(ss, token, ',')) {
+		if (!token.empty()) {
+			cols.push_back(token);
+		}
+	}
+	return cols;
+}
+
 vector<string> RefreshMetadata::GetAggregateTypes(const string &view_name) {
 	auto result = con.Query("SELECT aggregate_types FROM " + string(openivm::VIEWS_TABLE) + " WHERE view_name = '" +
 	                        SqlUtils::EscapeValue(view_name) + "'");

--- a/src/include/core/incremental_checker.hpp
+++ b/src/include/core/incremental_checker.hpp
@@ -49,6 +49,8 @@ struct PlanAnalysis {
 	vector<string> aggregate_types;          // per-column: "min", "max", "sum", "count_star", "count", "avg", "list"
 	vector<string> window_partition_columns; // PARTITION BY source columns from window functions
 	vector<idx_t> window_partition_column_indexes; // Output-position hint for each PARTITION BY column
+	vector<string> window_order_columns;           // Common simple ORDER BY columns for all window expressions
+	bool window_row_key_compatible = true;         // False when window expressions use different/non-column keys
 	size_t group_count = 0;                        // number of GROUP BY expressions
 	idx_t group_index = DConstants::INVALID_INDEX; // aggregate's group_index for binding lookup
 };

--- a/src/include/core/ivm_view_classifier.hpp
+++ b/src/include/core/ivm_view_classifier.hpp
@@ -176,6 +176,7 @@ struct DeltaViewModel {
 	vector<DeltaStrategyReason> strategy_reasons;
 	vector<string> group_columns;
 	vector<string> window_partition_columns;
+	vector<string> window_order_columns;
 	vector<string> aggregate_types;
 	vector<DeltaModelFeature> features;
 	vector<DeltaUnsupportedReason> unsupported_reasons;

--- a/src/include/core/refresh_metadata.hpp
+++ b/src/include/core/refresh_metadata.hpp
@@ -123,6 +123,10 @@ public:
 	// Get GROUP BY column names for a view. Returns empty vector if not stored.
 	vector<string> GetGroupColumns(const string &view_name);
 
+	// Get common window ORDER BY output/source mappings. Empty means the view
+	// predates this metadata or its window specifications do not share a simple key.
+	vector<string> GetWindowOrderColumns(const string &view_name);
+
 	// Get per-column aggregate function types (min, max, sum, count_star, etc.).
 	vector<string> GetAggregateTypes(const string &view_name);
 

--- a/src/upsert/refresh_window.cpp
+++ b/src/upsert/refresh_window.cpp
@@ -386,6 +386,98 @@ static string BuildAffectedPartitionRefreshSQL(const string &data_table, const s
 	                                  affected_temp_table);
 }
 
+static bool AddWindowRowKeyColumns(const vector<string> &specs, const vector<string> &visible_columns,
+                                   vector<string> &row_keys) {
+	for (auto &spec : specs) {
+		auto output_column = SplitPartitionSpec(spec).first;
+		auto visible = std::find_if(visible_columns.begin(), visible_columns.end(),
+		                            [&](const string &column) { return StringUtil::CIEquals(column, output_column); });
+		if (visible == visible_columns.end()) {
+			return false;
+		}
+		auto duplicate = std::find_if(row_keys.begin(), row_keys.end(),
+		                              [&](const string &column) { return StringUtil::CIEquals(column, *visible); });
+		if (duplicate == row_keys.end()) {
+			row_keys.push_back(*visible);
+		}
+	}
+	return true;
+}
+
+static string QualifiedColumns(const vector<string> &columns, const string &alias) {
+	string result;
+	for (idx_t i = 0; i < columns.size(); i++) {
+		if (i > 0) {
+			result += ", ";
+		}
+		result += alias + "." + SqlUtils::QuoteIdentifier(columns[i]);
+	}
+	return result;
+}
+
+static string BuildDuckLakeWindowRowDiffRefreshSQL(const string &view_name, const string &data_table,
+                                                   const string &view_query_sql, const string &affected_keys_sql,
+                                                   const vector<string> &partition_cols,
+                                                   const vector<string> &order_cols,
+                                                   const vector<string> &column_names) {
+	vector<string> visible_columns;
+	for (auto &column : column_names) {
+		if (!IncrementalTableNames::IsInternalColumn(column)) {
+			visible_columns.push_back(column);
+		}
+	}
+	vector<string> row_keys;
+	if (visible_columns.empty() || !AddWindowRowKeyColumns(partition_cols, visible_columns, row_keys) ||
+	    !AddWindowRowKeyColumns(order_cols, visible_columns, row_keys) || row_keys.empty()) {
+		return "";
+	}
+
+	string affected_table = SqlUtils::QuoteIdentifier(string(openivm::TEMP_TABLE_PREFIX) + "affected_" + view_name);
+	string recompute_table = SqlUtils::QuoteIdentifier("openivm_window_recompute_" + view_name);
+	string changed_table = SqlUtils::QuoteIdentifier("openivm_window_changed_" + view_name);
+	auto partition_output_columns = PartitionOutputColumns(partition_cols);
+	string target_affected = SqlUtils::BuildNullSafeMatch(partition_output_columns, "openivm_aff", "openivm_target");
+	string recompute_affected =
+	    SqlUtils::BuildNullSafeMatch(partition_output_columns, "openivm_aff", "openivm_recompute");
+	string row_key_match = SqlUtils::BuildNullSafeMatch(row_keys, "openivm_old", "openivm_new");
+	string old_columns = QualifiedColumns(visible_columns, "openivm_target");
+	string new_columns = QualifiedColumns(visible_columns, "openivm_recompute");
+	string changed_new_columns = QualifiedColumns(visible_columns, "openivm_new");
+	string insert_columns = SqlUtils::JoinQuotedColumns(visible_columns);
+	string distinct_rows = "(" + QualifiedColumns(visible_columns, "openivm_old") + ") IS DISTINCT FROM (" +
+	                       QualifiedColumns(visible_columns, "openivm_new") + ")";
+
+	string old_partition_by = QualifiedColumns(row_keys, "openivm_target");
+	string new_partition_by = QualifiedColumns(row_keys, "openivm_recompute");
+	string sql;
+	sql += "CREATE OR REPLACE TEMP TABLE " + affected_table + " AS\n" + affected_keys_sql + ";\n\n";
+	sql += "CREATE OR REPLACE TEMP TABLE " + recompute_table + " AS\nSELECT * FROM (" + view_query_sql +
+	       ") openivm_recompute\nWHERE EXISTS (SELECT 1 FROM " + affected_table + " openivm_aff WHERE " +
+	       recompute_affected + ");\n\n";
+	sql += "CREATE OR REPLACE TEMP TABLE " + changed_table + " AS\nWITH openivm_old AS (\n  SELECT " + old_columns +
+	       ", openivm_target.rowid AS openivm_old_rowid,\n    ROW_NUMBER() OVER (PARTITION BY " + old_partition_by +
+	       ") AS openivm_match_id\n  FROM " + data_table + " openivm_target\n  WHERE EXISTS (SELECT 1 FROM " +
+	       affected_table + " openivm_aff WHERE " + target_affected + ")\n), openivm_new AS (\n  SELECT " +
+	       new_columns + ", TRUE AS openivm_new_present,\n    ROW_NUMBER() OVER (PARTITION BY " + new_partition_by +
+	       ") AS openivm_match_id\n  FROM " + recompute_table + " openivm_recompute\n)\nSELECT " +
+	       "openivm_old.openivm_old_rowid, openivm_new.openivm_new_present, " + changed_new_columns +
+	       "\nFROM openivm_old\nFULL OUTER JOIN openivm_new ON " + row_key_match +
+	       " AND openivm_old.openivm_match_id = openivm_new.openivm_match_id\nWHERE " +
+	       "openivm_old.openivm_old_rowid IS NULL OR openivm_new.openivm_new_present IS NULL OR " + distinct_rows +
+	       ";\n\n";
+	sql += "DELETE FROM " + data_table + " WHERE rowid IN (SELECT openivm_old_rowid FROM " + changed_table +
+	       " WHERE openivm_old_rowid IS NOT NULL);\n\n";
+	sql += "INSERT INTO " + data_table + " (" + insert_columns + ")\nSELECT " +
+	       QualifiedColumns(visible_columns, "openivm_changed") + "\nFROM " + changed_table +
+	       " openivm_changed\nWHERE openivm_new_present;\n\n";
+	sql += "DROP TABLE IF EXISTS " + changed_table + ";\n";
+	sql += "DROP TABLE IF EXISTS " + recompute_table + ";\n";
+	sql += "DROP TABLE IF EXISTS " + affected_table + ";\n";
+	OPENIVM_DEBUG_PRINT("[UPSERT] WINDOW_PARTITION DuckLake compact row diff for %s (%zu row keys)\n",
+	                    view_name.c_str(), row_keys.size());
+	return sql;
+}
+
 static bool BuildLineageDuckLakeAffectedKeysSQL(RefreshMetadata &metadata, Connection &con, const string &view_name,
                                                 const vector<string> &delta_table_names,
                                                 const vector<string> &partition_cols, const string &view_catalog_name,
@@ -454,12 +546,11 @@ static bool BuildLineageDuckLakeAffectedKeysSQL(RefreshMetadata &metadata, Conne
 	return true;
 }
 
-static string BuildSingleSourceDuckLakeWindowRefresh(RefreshMetadata &metadata, Connection &con,
-                                                     const string &view_name, const string &view_query_sql,
-                                                     const vector<string> &partition_cols, const string &data_table,
-                                                     const string &view_catalog_name, const string &view_schema_name,
-                                                     const string &attached_db_catalog_name,
-                                                     const string &attached_db_schema_name, const string &base_name) {
+static string BuildSingleSourceDuckLakeWindowRefresh(
+    RefreshMetadata &metadata, Connection &con, const string &view_name, const string &view_query_sql,
+    const vector<string> &partition_cols, const vector<string> &order_cols, const vector<string> &column_names,
+    const string &data_table, const string &view_catalog_name, const string &view_schema_name,
+    const string &attached_db_catalog_name, const string &attached_db_schema_name, const string &base_name) {
 	int64_t old_snap = metadata.GetLastSnapshotId(view_name, base_name);
 	auto loc = ResolveDuckLakeSourceLocation(con, view_name, base_name, view_catalog_name, view_schema_name,
 	                                         attached_db_catalog_name, attached_db_schema_name);
@@ -491,6 +582,13 @@ static string BuildSingleSourceDuckLakeWindowRefresh(RefreshMetadata &metadata, 
 	                                                   loc.table_name, old_snap, current_snap);
 	string affected_keys = "SELECT DISTINCT " + affected_cols + " FROM ((" + insertions + ") UNION ALL (" + deletions +
 	                       ")) openivm_changed_partitions";
+	if (!order_cols.empty()) {
+		auto compact_diff = BuildDuckLakeWindowRowDiffRefreshSQL(view_name, data_table, view_query_sql, affected_keys,
+		                                                         partition_cols, order_cols, column_names);
+		if (!compact_diff.empty()) {
+			return compact_diff;
+		}
+	}
 	string upsert_query =
 	    BuildAffectedPartitionRefreshSQL(data_table, view_query_sql, affected_keys, qtemp_affected, partition_cols);
 	OPENIVM_DEBUG_PRINT("[UPSERT] Compiling upsert for type: WINDOW_PARTITION (DuckLake change-feed, %zu "
@@ -557,6 +655,7 @@ string BuildWindowPartitionRefresh(RefreshMetadata &metadata, Connection &con, c
                                    const string &attached_db_catalog_name, const string &attached_db_schema_name,
                                    bool cross_system, bool emit_cascade_delta, bool running_window_incremental) {
 	auto partition_cols = metadata.GetGroupColumns(view_name); // reuses group_columns field
+	auto order_cols = metadata.GetWindowOrderColumns(view_name);
 	auto partition_delta_specs =
 	    BuildWindowPartitionDeltaSpecs(metadata, con, view_name, delta_table_names, partition_cols, cross_system);
 	bool any_ducklake = AnyDuckLakeSource(metadata, view_name, delta_table_names);
@@ -565,9 +664,10 @@ string BuildWindowPartitionRefresh(RefreshMetadata &metadata, Connection &con, c
 	bool have_lineage_affected_keys = false;
 
 	if (safe_for_snapdiff && delta_table_names.size() == 1) {
-		return BuildSingleSourceDuckLakeWindowRefresh(
-		    metadata, con, view_name, view_query_sql, partition_cols, data_table, view_catalog_name, view_schema_name,
-		    attached_db_catalog_name, attached_db_schema_name, delta_table_names[0]);
+		return BuildSingleSourceDuckLakeWindowRefresh(metadata, con, view_name, view_query_sql, partition_cols,
+		                                              order_cols, column_names, data_table, view_catalog_name,
+		                                              view_schema_name, attached_db_catalog_name,
+		                                              attached_db_schema_name, delta_table_names[0]);
 	}
 	if (safe_for_snapdiff && any_ducklake) {
 		return BuildMultiSourceDuckLakeWindowRefresh(metadata, con, view_name, view_query_sql, delta_table_names,

--- a/test/sql/ducklake_window.test
+++ b/test/sql/ducklake_window.test
@@ -180,6 +180,229 @@ SELECT count(*) FROM (
 ----
 0
 
+# A single-source ordered DuckLake window can pair old and new row occurrences
+# by PARTITION BY + ORDER BY, then write only the compact bag difference. The
+# duplicate (symbol, event_day) keys below ensure this does not assume a unique
+# window key.
+statement ok
+CREATE TABLE dl.window_compact_src (
+    event_day INT,
+    symbol VARCHAR,
+    low_value INT,
+    high_value INT,
+    payload INT
+);
+
+statement ok
+INSERT INTO dl.window_compact_src VALUES
+    (1, 'A', 10, 20, 100),
+    (1, 'A', 9, 21, 101),
+    (2, 'A', 8, 19, 102),
+    (3, 'A', 11, 23, 103),
+    (1, 'B', 30, 40, 200),
+    (2, 'B', 29, 39, 201);
+
+statement ok
+CREATE MATERIALIZED VIEW dl.mv_window_compact AS
+WITH cumulative AS (
+    SELECT
+        event_day,
+        symbol,
+        low_value,
+        high_value,
+        payload,
+        min(low_value) OVER w AS running_low,
+        max(high_value) OVER w AS running_high
+    FROM dl.window_compact_src
+    WINDOW w AS (PARTITION BY symbol ORDER BY event_day)
+), flagged AS (
+    SELECT
+        *,
+        CASE WHEN low_value = running_low THEN event_day END AS low_day_flag,
+        CASE WHEN high_value = running_high THEN event_day END AS high_day_flag
+    FROM cumulative
+)
+SELECT
+    event_day,
+    symbol,
+    low_value,
+    high_value,
+    payload,
+    running_low,
+    running_high,
+    max(low_day_flag) OVER (PARTITION BY symbol ORDER BY event_day) AS running_low_day,
+    max(high_day_flag) OVER (PARTITION BY symbol ORDER BY event_day) AS running_high_day
+FROM flagged;
+
+query T
+SELECT window_order_columns FROM openivm_views WHERE view_name = 'mv_window_compact';
+----
+event_day=event_day
+
+# Batch conflicting INSERT, UPDATE, and DELETE operations—including multiple
+# operations on the same logical key—before one refresh.
+statement ok
+INSERT INTO dl.window_compact_src VALUES (4, 'A', 7, 24, 104);
+
+statement ok
+UPDATE dl.window_compact_src SET high_value = 25, payload = 105
+WHERE symbol = 'A' AND event_day = 4;
+
+statement ok
+DELETE FROM dl.window_compact_src WHERE symbol = 'A' AND event_day = 4;
+
+statement ok
+INSERT INTO dl.window_compact_src VALUES
+    (4, 'A', 6, 26, 106),
+    (2, 'B', 28, 41, 202);
+
+statement ok
+UPDATE dl.window_compact_src SET low_value = 7, payload = 112
+WHERE symbol = 'A' AND event_day = 2 AND payload = 102;
+
+statement ok
+DELETE FROM dl.window_compact_src
+WHERE symbol = 'A' AND event_day = 1 AND payload = 100;
+
+statement ok
+PRAGMA refresh('mv_window_compact');
+
+query I
+SELECT contains(content, 'openivm_window_changed_mv_window_compact')::INT
+FROM read_text('__TEST_DIR__/openivm_upsert_queries_mv_window_compact.sql');
+----
+1
+
+query I
+WITH expected AS (
+    WITH cumulative AS (
+        SELECT event_day, symbol, low_value, high_value, payload,
+               min(low_value) OVER w AS running_low,
+               max(high_value) OVER w AS running_high
+        FROM dl.window_compact_src
+        WINDOW w AS (PARTITION BY symbol ORDER BY event_day)
+    ), flagged AS (
+        SELECT *,
+               CASE WHEN low_value = running_low THEN event_day END AS low_day_flag,
+               CASE WHEN high_value = running_high THEN event_day END AS high_day_flag
+        FROM cumulative
+    )
+    SELECT event_day, symbol, low_value, high_value, payload,
+           running_low, running_high,
+           max(low_day_flag) OVER (PARTITION BY symbol ORDER BY event_day) AS running_low_day,
+           max(high_day_flag) OVER (PARTITION BY symbol ORDER BY event_day) AS running_high_day
+    FROM flagged
+)
+SELECT count(*) FROM (
+    SELECT * FROM dl.mv_window_compact
+    EXCEPT ALL
+    SELECT * FROM expected
+);
+----
+0
+
+query I
+WITH expected AS (
+    WITH cumulative AS (
+        SELECT event_day, symbol, low_value, high_value, payload,
+               min(low_value) OVER w AS running_low,
+               max(high_value) OVER w AS running_high
+        FROM dl.window_compact_src
+        WINDOW w AS (PARTITION BY symbol ORDER BY event_day)
+    ), flagged AS (
+        SELECT *,
+               CASE WHEN low_value = running_low THEN event_day END AS low_day_flag,
+               CASE WHEN high_value = running_high THEN event_day END AS high_day_flag
+        FROM cumulative
+    )
+    SELECT event_day, symbol, low_value, high_value, payload,
+           running_low, running_high,
+           max(low_day_flag) OVER (PARTITION BY symbol ORDER BY event_day) AS running_low_day,
+           max(high_day_flag) OVER (PARTITION BY symbol ORDER BY event_day) AS running_high_day
+    FROM flagged
+)
+SELECT count(*) FROM (
+    SELECT * FROM expected
+    EXCEPT ALL
+    SELECT * FROM dl.mv_window_compact
+);
+----
+0
+
+# A second mixed batch verifies that the compact physical layout remains valid
+# for the next refresh rather than deferring work into the following batch.
+statement ok
+UPDATE dl.window_compact_src SET low_value = low_value - 2, payload = payload + 1000
+WHERE symbol = 'A' AND event_day = 1;
+
+statement ok
+DELETE FROM dl.window_compact_src
+WHERE symbol = 'B' AND event_day = 2 AND payload = 201;
+
+statement ok
+INSERT INTO dl.window_compact_src VALUES
+    (2, 'B', 27, 42, 203),
+    (3, 'B', 26, 43, 204);
+
+statement ok
+PRAGMA refresh('mv_window_compact');
+
+query I
+WITH expected AS (
+    WITH cumulative AS (
+        SELECT event_day, symbol, low_value, high_value, payload,
+               min(low_value) OVER w AS running_low,
+               max(high_value) OVER w AS running_high
+        FROM dl.window_compact_src
+        WINDOW w AS (PARTITION BY symbol ORDER BY event_day)
+    ), flagged AS (
+        SELECT *,
+               CASE WHEN low_value = running_low THEN event_day END AS low_day_flag,
+               CASE WHEN high_value = running_high THEN event_day END AS high_day_flag
+        FROM cumulative
+    )
+    SELECT event_day, symbol, low_value, high_value, payload,
+           running_low, running_high,
+           max(low_day_flag) OVER (PARTITION BY symbol ORDER BY event_day) AS running_low_day,
+           max(high_day_flag) OVER (PARTITION BY symbol ORDER BY event_day) AS running_high_day
+    FROM flagged
+)
+SELECT count(*) FROM (
+    SELECT * FROM dl.mv_window_compact
+    EXCEPT ALL
+    SELECT * FROM expected
+);
+----
+0
+
+query I
+WITH expected AS (
+    WITH cumulative AS (
+        SELECT event_day, symbol, low_value, high_value, payload,
+               min(low_value) OVER w AS running_low,
+               max(high_value) OVER w AS running_high
+        FROM dl.window_compact_src
+        WINDOW w AS (PARTITION BY symbol ORDER BY event_day)
+    ), flagged AS (
+        SELECT *,
+               CASE WHEN low_value = running_low THEN event_day END AS low_day_flag,
+               CASE WHEN high_value = running_high THEN event_day END AS high_day_flag
+        FROM cumulative
+    )
+    SELECT event_day, symbol, low_value, high_value, payload,
+           running_low, running_high,
+           max(low_day_flag) OVER (PARTITION BY symbol ORDER BY event_day) AS running_low_day,
+           max(high_day_flag) OVER (PARTITION BY symbol ORDER BY event_day) AS running_high_day
+    FROM flagged
+)
+SELECT count(*) FROM (
+    SELECT * FROM expected
+    EXCEPT ALL
+    SELECT * FROM dl.mv_window_compact
+);
+----
+0
+
 statement ok
 CREATE TABLE dl.window_composite_src (
     w_id INT,


### PR DESCRIPTION
## Summary

- persist a common simple `ORDER BY` key for window views
- for single-source DuckLake ordered windows, recompute affected partitions but apply only their compact bag difference
- pair duplicate key occurrences with `ROW_NUMBER`, delete exact old `rowid`s, and insert only changed/new rows
- retain the existing affected-partition replacement path when window specifications are incompatible or metadata is unavailable

## Why

The existing DuckLake window refresh rewrites every row in an affected partition. For `daily_market`, almost the entire 27.2M-row result is affected, so that write amplification also fragments the table and makes the following batch slower. The compact diff preserves the same recomputation semantics while reducing physical writes to rows whose output actually changed.

In the isolated SF50 `daily_market` experiment that motivated this change:

- batch 2: 13.56s existing OpenIVM, 4.00s compact diff, 4.56s full refresh
- sequential batch 3: 26.54s existing OpenIVM, 4.58s compact diff, 4.64s full refresh

Both compact-diff batches matched the full query in both `EXCEPT ALL` directions.

## Tests

- `GEN=ninja make`
- `make tidy-check`
- `build/release/test/unittest "test/sql/ducklake_window.test"` (139 assertions)
- `build/release/test/unittest "test/sql/window_running_aggregate_daily_market_window_over_window.test"`
- standalone DuckDB CLI DuckLake materialized-view refresh with mixed insert/update/delete operations and duplicate order keys; both `EXCEPT ALL` directions returned 0
