### PR TITLE
Simplify materialized view plan analysis

### DIFF
--- a/benchmark/queries/query_0116.sql
+++ b/benchmark/queries/query_0116.sql
@@ -1,2 +1,2 @@
--- {"operators": "LIMIT", "complexity": "low", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "CUSTOMER"}
+-- {"operators": "LIMIT", "complexity": "low", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "CUSTOMER", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT * FROM CUSTOMER LIMIT 4;

--- a/benchmark/queries/query_0119.sql
+++ b/benchmark/queries/query_0119.sql
@@ -1,2 +1,2 @@
--- {"operators": "LIMIT", "complexity": "low", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "OORDER"}
+-- {"operators": "LIMIT", "complexity": "low", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "OORDER", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT * FROM OORDER LIMIT 3;

--- a/benchmark/queries/query_0120.sql
+++ b/benchmark/queries/query_0120.sql
@@ -1,2 +1,2 @@
--- {"operators": "LIMIT", "complexity": "low", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "OORDER"}
+-- {"operators": "LIMIT", "complexity": "low", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "OORDER", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT * FROM OORDER LIMIT 4;

--- a/benchmark/queries/query_0408.sql
+++ b/benchmark/queries/query_0408.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,LIMIT", "complexity": "low", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,LIMIT", "complexity": "low", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, COUNT(*), SUM(W_YTD), AVG(W_TAX) FROM WAREHOUSE GROUP BY W_ID LIMIT 20;

--- a/benchmark/queries/query_0415.sql
+++ b/benchmark/queries/query_0415.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, COUNT(W_TAX) FROM WAREHOUSE WHERE W_TAX > 0 GROUP BY W_ID HAVING COUNT(W_TAX) < 1 LIMIT 1;

--- a/benchmark/queries/query_0417.sql
+++ b/benchmark/queries/query_0417.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, SUM(W_TAX) FROM WAREHOUSE WHERE W_TAX > 0 GROUP BY W_ID HAVING SUM(W_TAX) > 0 LIMIT 10;

--- a/benchmark/queries/query_0418.sql
+++ b/benchmark/queries/query_0418.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, SUM(W_TAX) FROM WAREHOUSE WHERE W_TAX > 0 GROUP BY W_ID HAVING SUM(W_TAX) > 1 LIMIT 10;

--- a/benchmark/queries/query_0419.sql
+++ b/benchmark/queries/query_0419.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, SUM(W_TAX) FROM WAREHOUSE WHERE W_TAX > 0 GROUP BY W_ID HAVING SUM(W_TAX) < 1 LIMIT 10;

--- a/benchmark/queries/query_0421.sql
+++ b/benchmark/queries/query_0421.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, MIN(W_TAX) FROM WAREHOUSE WHERE W_TAX > 0 GROUP BY W_ID HAVING MIN(W_TAX) < 1 LIMIT 10;

--- a/benchmark/queries/query_0423.sql
+++ b/benchmark/queries/query_0423.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, MAX(W_TAX) FROM WAREHOUSE WHERE W_TAX > 0 GROUP BY W_ID HAVING MAX(W_TAX) > 0 LIMIT 5;

--- a/benchmark/queries/query_0424.sql
+++ b/benchmark/queries/query_0424.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, MAX(W_TAX) FROM WAREHOUSE WHERE W_TAX > 0 GROUP BY W_ID HAVING MAX(W_TAX) < 0 LIMIT 1;

--- a/benchmark/queries/query_0425.sql
+++ b/benchmark/queries/query_0425.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, MAX(W_TAX) FROM WAREHOUSE WHERE W_TAX > 0 GROUP BY W_ID HAVING MAX(W_TAX) < 1 LIMIT 5;

--- a/benchmark/queries/query_0426.sql
+++ b/benchmark/queries/query_0426.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, MAX(W_TAX) FROM WAREHOUSE WHERE W_TAX > 0 GROUP BY W_ID HAVING MAX(W_TAX) < 5 LIMIT 5;

--- a/benchmark/queries/query_0427.sql
+++ b/benchmark/queries/query_0427.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, MAX(W_TAX) FROM WAREHOUSE WHERE W_TAX > 0 GROUP BY W_ID HAVING MAX(W_TAX) < 10 LIMIT 5;

--- a/benchmark/queries/query_0428.sql
+++ b/benchmark/queries/query_0428.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, COUNT(W_TAX) FROM WAREHOUSE WHERE W_TAX > 1 GROUP BY W_ID HAVING COUNT(W_TAX) > 1 LIMIT 5;

--- a/benchmark/queries/query_0429.sql
+++ b/benchmark/queries/query_0429.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, COUNT(W_TAX) FROM WAREHOUSE WHERE W_TAX > 1 GROUP BY W_ID HAVING COUNT(W_TAX) < 0 LIMIT 1;

--- a/benchmark/queries/query_0430.sql
+++ b/benchmark/queries/query_0430.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, COUNT(W_TAX) FROM WAREHOUSE WHERE W_TAX > 1 GROUP BY W_ID HAVING COUNT(W_TAX) < 0 LIMIT 10;

--- a/benchmark/queries/query_0431.sql
+++ b/benchmark/queries/query_0431.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, AVG(W_TAX) FROM WAREHOUSE WHERE W_TAX > 1 GROUP BY W_ID HAVING AVG(W_TAX) > 5 LIMIT 1;

--- a/benchmark/queries/query_0432.sql
+++ b/benchmark/queries/query_0432.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, AVG(W_TAX) FROM WAREHOUSE WHERE W_TAX > 1 GROUP BY W_ID HAVING AVG(W_TAX) > 10 LIMIT 1;

--- a/benchmark/queries/query_0433.sql
+++ b/benchmark/queries/query_0433.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, MIN(W_TAX) FROM WAREHOUSE WHERE W_TAX > 1 GROUP BY W_ID HAVING MIN(W_TAX) < 0 LIMIT 1;

--- a/benchmark/queries/query_0434.sql
+++ b/benchmark/queries/query_0434.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, MIN(W_TAX) FROM WAREHOUSE WHERE W_TAX > 1 GROUP BY W_ID HAVING MIN(W_TAX) < 1 LIMIT 10;

--- a/benchmark/queries/query_0435.sql
+++ b/benchmark/queries/query_0435.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, MIN(W_TAX) FROM WAREHOUSE WHERE W_TAX > 1 GROUP BY W_ID HAVING MIN(W_TAX) < 10 LIMIT 10;

--- a/benchmark/queries/query_0436.sql
+++ b/benchmark/queries/query_0436.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, COUNT(W_TAX) FROM WAREHOUSE WHERE W_TAX > 50 GROUP BY W_ID HAVING COUNT(W_TAX) < 10 LIMIT 5;

--- a/benchmark/queries/query_0437.sql
+++ b/benchmark/queries/query_0437.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, AVG(W_TAX) FROM WAREHOUSE WHERE W_TAX > 50 GROUP BY W_ID HAVING AVG(W_TAX) > 1 LIMIT 1;

--- a/benchmark/queries/query_0438.sql
+++ b/benchmark/queries/query_0438.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, AVG(W_TAX) FROM WAREHOUSE WHERE W_TAX > 50 GROUP BY W_ID HAVING AVG(W_TAX) > 5 LIMIT 1;

--- a/benchmark/queries/query_0439.sql
+++ b/benchmark/queries/query_0439.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, AVG(W_TAX) FROM WAREHOUSE WHERE W_TAX > 50 GROUP BY W_ID HAVING AVG(W_TAX) < 1 LIMIT 1;

--- a/benchmark/queries/query_0440.sql
+++ b/benchmark/queries/query_0440.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, AVG(W_TAX) FROM WAREHOUSE WHERE W_TAX > 50 GROUP BY W_ID HAVING AVG(W_TAX) < 10 LIMIT 5;

--- a/benchmark/queries/query_0441.sql
+++ b/benchmark/queries/query_0441.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, MIN(W_TAX) FROM WAREHOUSE WHERE W_TAX > 50 GROUP BY W_ID HAVING MIN(W_TAX) > 5 LIMIT 5;

--- a/benchmark/queries/query_0442.sql
+++ b/benchmark/queries/query_0442.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, MAX(W_TAX) FROM WAREHOUSE WHERE W_TAX > 50 GROUP BY W_ID HAVING MAX(W_TAX) > 0 LIMIT 1;

--- a/benchmark/queries/query_0443.sql
+++ b/benchmark/queries/query_0443.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, MAX(W_TAX) FROM WAREHOUSE WHERE W_TAX > 50 GROUP BY W_ID HAVING MAX(W_TAX) < 0 LIMIT 1;

--- a/benchmark/queries/query_0444.sql
+++ b/benchmark/queries/query_0444.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, MAX(W_TAX) FROM WAREHOUSE WHERE W_TAX > 50 GROUP BY W_ID HAVING MAX(W_TAX) < 0 LIMIT 5;

--- a/benchmark/queries/query_0445.sql
+++ b/benchmark/queries/query_0445.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, COUNT(W_TAX) FROM WAREHOUSE WHERE W_TAX > 100 GROUP BY W_ID HAVING COUNT(W_TAX) > 0 LIMIT 5;

--- a/benchmark/queries/query_0446.sql
+++ b/benchmark/queries/query_0446.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, COUNT(W_TAX) FROM WAREHOUSE WHERE W_TAX > 100 GROUP BY W_ID HAVING COUNT(W_TAX) > 1 LIMIT 1;

--- a/benchmark/queries/query_0447.sql
+++ b/benchmark/queries/query_0447.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, COUNT(W_TAX) FROM WAREHOUSE WHERE W_TAX > 100 GROUP BY W_ID HAVING COUNT(W_TAX) > 5 LIMIT 10;

--- a/benchmark/queries/query_0448.sql
+++ b/benchmark/queries/query_0448.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, COUNT(W_TAX) FROM WAREHOUSE WHERE W_TAX > 100 GROUP BY W_ID HAVING COUNT(W_TAX) < 5 LIMIT 1;

--- a/benchmark/queries/query_0449.sql
+++ b/benchmark/queries/query_0449.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, SUM(W_TAX) FROM WAREHOUSE WHERE W_TAX > 100 GROUP BY W_ID HAVING SUM(W_TAX) > 1 LIMIT 5;

--- a/benchmark/queries/query_0450.sql
+++ b/benchmark/queries/query_0450.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, SUM(W_TAX) FROM WAREHOUSE WHERE W_TAX > 100 GROUP BY W_ID HAVING SUM(W_TAX) > 10 LIMIT 10;

--- a/benchmark/queries/query_0451.sql
+++ b/benchmark/queries/query_0451.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, SUM(W_TAX) FROM WAREHOUSE WHERE W_TAX > 100 GROUP BY W_ID HAVING SUM(W_TAX) < 1 LIMIT 1;

--- a/benchmark/queries/query_0452.sql
+++ b/benchmark/queries/query_0452.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, AVG(W_TAX) FROM WAREHOUSE WHERE W_TAX > 100 GROUP BY W_ID HAVING AVG(W_TAX) > 0 LIMIT 1;

--- a/benchmark/queries/query_0453.sql
+++ b/benchmark/queries/query_0453.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, AVG(W_TAX) FROM WAREHOUSE WHERE W_TAX > 100 GROUP BY W_ID HAVING AVG(W_TAX) > 0 LIMIT 10;

--- a/benchmark/queries/query_0454.sql
+++ b/benchmark/queries/query_0454.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, AVG(W_TAX) FROM WAREHOUSE WHERE W_TAX > 100 GROUP BY W_ID HAVING AVG(W_TAX) < 0 LIMIT 10;

--- a/benchmark/queries/query_0455.sql
+++ b/benchmark/queries/query_0455.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, AVG(W_TAX) FROM WAREHOUSE WHERE W_TAX > 100 GROUP BY W_ID HAVING AVG(W_TAX) < 10 LIMIT 10;

--- a/benchmark/queries/query_0456.sql
+++ b/benchmark/queries/query_0456.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, MIN(W_TAX) FROM WAREHOUSE WHERE W_TAX > 100 GROUP BY W_ID HAVING MIN(W_TAX) > 1 LIMIT 10;

--- a/benchmark/queries/query_0457.sql
+++ b/benchmark/queries/query_0457.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, MIN(W_TAX) FROM WAREHOUSE WHERE W_TAX > 100 GROUP BY W_ID HAVING MIN(W_TAX) < 0 LIMIT 1;

--- a/benchmark/queries/query_0458.sql
+++ b/benchmark/queries/query_0458.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, MAX(W_TAX) FROM WAREHOUSE WHERE W_TAX > 100 GROUP BY W_ID HAVING MAX(W_TAX) > 1 LIMIT 1;

--- a/benchmark/queries/query_0459.sql
+++ b/benchmark/queries/query_0459.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, MAX(W_TAX) FROM WAREHOUSE WHERE W_TAX > 100 GROUP BY W_ID HAVING MAX(W_TAX) > 5 LIMIT 5;

--- a/benchmark/queries/query_0460.sql
+++ b/benchmark/queries/query_0460.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, MAX(W_TAX) FROM WAREHOUSE WHERE W_TAX > 100 GROUP BY W_ID HAVING MAX(W_TAX) > 10 LIMIT 5;

--- a/benchmark/queries/query_0461.sql
+++ b/benchmark/queries/query_0461.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, MAX(W_TAX) FROM WAREHOUSE WHERE W_TAX > 100 GROUP BY W_ID HAVING MAX(W_TAX) < 10 LIMIT 5;

--- a/benchmark/queries/query_0462.sql
+++ b/benchmark/queries/query_0462.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, COUNT(W_TAX) FROM WAREHOUSE WHERE W_TAX < 0 GROUP BY W_ID HAVING COUNT(W_TAX) > 10 LIMIT 10;

--- a/benchmark/queries/query_0463.sql
+++ b/benchmark/queries/query_0463.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, COUNT(W_TAX) FROM WAREHOUSE WHERE W_TAX < 0 GROUP BY W_ID HAVING COUNT(W_TAX) < 0 LIMIT 1;

--- a/benchmark/queries/query_0464.sql
+++ b/benchmark/queries/query_0464.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, COUNT(W_TAX) FROM WAREHOUSE WHERE W_TAX < 0 GROUP BY W_ID HAVING COUNT(W_TAX) < 5 LIMIT 5;

--- a/benchmark/queries/query_0465.sql
+++ b/benchmark/queries/query_0465.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, COUNT(W_TAX) FROM WAREHOUSE WHERE W_TAX < 0 GROUP BY W_ID HAVING COUNT(W_TAX) < 10 LIMIT 10;

--- a/benchmark/queries/query_0466.sql
+++ b/benchmark/queries/query_0466.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, SUM(W_TAX) FROM WAREHOUSE WHERE W_TAX < 0 GROUP BY W_ID HAVING SUM(W_TAX) > 0 LIMIT 1;

--- a/benchmark/queries/query_0467.sql
+++ b/benchmark/queries/query_0467.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, SUM(W_TAX) FROM WAREHOUSE WHERE W_TAX < 0 GROUP BY W_ID HAVING SUM(W_TAX) < 5 LIMIT 1;

--- a/benchmark/queries/query_0468.sql
+++ b/benchmark/queries/query_0468.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, SUM(W_TAX) FROM WAREHOUSE WHERE W_TAX < 0 GROUP BY W_ID HAVING SUM(W_TAX) < 10 LIMIT 5;

--- a/benchmark/queries/query_0469.sql
+++ b/benchmark/queries/query_0469.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, AVG(W_TAX) FROM WAREHOUSE WHERE W_TAX < 0 GROUP BY W_ID HAVING AVG(W_TAX) > 5 LIMIT 10;

--- a/benchmark/queries/query_0470.sql
+++ b/benchmark/queries/query_0470.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, MIN(W_TAX) FROM WAREHOUSE WHERE W_TAX < 0 GROUP BY W_ID HAVING MIN(W_TAX) < 5 LIMIT 1;

--- a/benchmark/queries/query_0471.sql
+++ b/benchmark/queries/query_0471.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, MIN(W_TAX) FROM WAREHOUSE WHERE W_TAX < 0 GROUP BY W_ID HAVING MIN(W_TAX) < 5 LIMIT 5;

--- a/benchmark/queries/query_0472.sql
+++ b/benchmark/queries/query_0472.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, MIN(W_TAX) FROM WAREHOUSE WHERE W_TAX < 0 GROUP BY W_ID HAVING MIN(W_TAX) < 10 LIMIT 1;

--- a/benchmark/queries/query_0473.sql
+++ b/benchmark/queries/query_0473.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, MAX(W_TAX) FROM WAREHOUSE WHERE W_TAX < 0 GROUP BY W_ID HAVING MAX(W_TAX) < 5 LIMIT 1;

--- a/benchmark/queries/query_0474.sql
+++ b/benchmark/queries/query_0474.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, MAX(W_TAX) FROM WAREHOUSE WHERE W_TAX < 0 GROUP BY W_ID HAVING MAX(W_TAX) < 10 LIMIT 10;

--- a/benchmark/queries/query_0475.sql
+++ b/benchmark/queries/query_0475.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, COUNT(W_TAX) FROM WAREHOUSE WHERE W_TAX < 1 GROUP BY W_ID HAVING COUNT(W_TAX) < 0 LIMIT 1;

--- a/benchmark/queries/query_0476.sql
+++ b/benchmark/queries/query_0476.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, COUNT(W_TAX) FROM WAREHOUSE WHERE W_TAX < 1 GROUP BY W_ID HAVING COUNT(W_TAX) < 5 LIMIT 10;

--- a/benchmark/queries/query_0477.sql
+++ b/benchmark/queries/query_0477.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, SUM(W_TAX) FROM WAREHOUSE WHERE W_TAX < 1 GROUP BY W_ID HAVING SUM(W_TAX) > 1 LIMIT 1;

--- a/benchmark/queries/query_0478.sql
+++ b/benchmark/queries/query_0478.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, SUM(W_TAX) FROM WAREHOUSE WHERE W_TAX < 1 GROUP BY W_ID HAVING SUM(W_TAX) > 5 LIMIT 10;

--- a/benchmark/queries/query_0479.sql
+++ b/benchmark/queries/query_0479.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, SUM(W_TAX) FROM WAREHOUSE WHERE W_TAX < 1 GROUP BY W_ID HAVING SUM(W_TAX) > 10 LIMIT 10;

--- a/benchmark/queries/query_0480.sql
+++ b/benchmark/queries/query_0480.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, AVG(W_TAX) FROM WAREHOUSE WHERE W_TAX < 1 GROUP BY W_ID HAVING AVG(W_TAX) > 1 LIMIT 1;

--- a/benchmark/queries/query_0481.sql
+++ b/benchmark/queries/query_0481.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, AVG(W_TAX) FROM WAREHOUSE WHERE W_TAX < 1 GROUP BY W_ID HAVING AVG(W_TAX) > 10 LIMIT 5;

--- a/benchmark/queries/query_0482.sql
+++ b/benchmark/queries/query_0482.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, AVG(W_TAX) FROM WAREHOUSE WHERE W_TAX < 1 GROUP BY W_ID HAVING AVG(W_TAX) < 0 LIMIT 10;

--- a/benchmark/queries/query_0483.sql
+++ b/benchmark/queries/query_0483.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT W_ID, MIN(W_TAX) FROM WAREHOUSE WHERE W_TAX < 1 GROUP BY W_ID HAVING MIN(W_TAX) < 1 LIMIT 10;

--- a/benchmark/queries/query_0484.sql
+++ b/benchmark/queries/query_0484.sql
@@ -1,2 +1,2 @@
--- {"operators": "LIMIT,DISTINCT", "complexity": "low", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE"}
+-- {"operators": "LIMIT,DISTINCT", "complexity": "low", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT DISTINCT W_ID, W_TAX FROM WAREHOUSE LIMIT 10;

--- a/benchmark/queries/query_0488.sql
+++ b/benchmark/queries/query_0488.sql
@@ -1,2 +1,2 @@
--- {"operators": "LIMIT,DISTINCT", "complexity": "low", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "ORDER_LINE"}
+-- {"operators": "LIMIT,DISTINCT", "complexity": "low", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "ORDER_LINE", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT DISTINCT OL_W_ID FROM ORDER_LINE LIMIT 10;

--- a/benchmark/queries/query_0492.sql
+++ b/benchmark/queries/query_0492.sql
@@ -1,2 +1,2 @@
--- {"operators": "OUTER_JOIN,AGGREGATE,LIMIT", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE,DISTRICT"}
+-- {"operators": "OUTER_JOIN,AGGREGATE,LIMIT", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE,DISTRICT", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT WAREHOUSE.W_ID, COUNT(*) FROM WAREHOUSE LEFT JOIN DISTRICT ON WAREHOUSE.W_ID = DISTRICT.D_W_ID GROUP BY WAREHOUSE.W_ID LIMIT 10;

--- a/benchmark/queries/query_0495.sql
+++ b/benchmark/queries/query_0495.sql
@@ -1,2 +1,2 @@
--- {"operators": "OUTER_JOIN,AGGREGATE,LIMIT", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE,STOCK"}
+-- {"operators": "OUTER_JOIN,AGGREGATE,LIMIT", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE,STOCK", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT WAREHOUSE.W_ID, COUNT(*) FROM WAREHOUSE LEFT JOIN STOCK ON WAREHOUSE.W_ID = STOCK.S_W_ID GROUP BY WAREHOUSE.W_ID LIMIT 10;

--- a/benchmark/queries/query_1566.sql
+++ b/benchmark/queries/query_1566.sql
@@ -1,2 +1,2 @@
--- {"operators": "LIMIT", "complexity": "low", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "ITEM"}
+-- {"operators": "LIMIT", "complexity": "low", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "ITEM", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT I_ID, I_NAME, REGEXP_MATCHES(I_NAME, '[A-Z]+') AS matches FROM ITEM LIMIT 50;

--- a/benchmark/queries/query_1989.sql
+++ b/benchmark/queries/query_1989.sql
@@ -1,2 +1,2 @@
--- {"operators": "CROSS_JOIN,FILTER,LIMIT", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "CUSTOMER,ITEM"}
+-- {"operators": "CROSS_JOIN,FILTER,LIMIT", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "CUSTOMER,ITEM", "mv_verified": true, "refresh_type": "FULL_REFRESH"}
 SELECT c.C_W_ID, c.C_ID, c.C_LAST, i.I_NAME FROM CUSTOMER c CROSS JOIN ITEM i WHERE c.C_LAST LIKE SUBSTRING(i.I_NAME FROM 1 FOR 1) || '%' LIMIT 100;

--- a/benchmark/queries/tpcc/query_0116.sql
+++ b/benchmark/queries/tpcc/query_0116.sql
@@ -1,2 +1,2 @@
--- {"operators": "LIMIT", "complexity": "low", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "CUSTOMER", "refresh_type": "RECOMPUTE"}
+-- {"operators": "LIMIT", "complexity": "low", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "CUSTOMER", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT * FROM CUSTOMER LIMIT 4;

--- a/benchmark/queries/tpcc/query_0119.sql
+++ b/benchmark/queries/tpcc/query_0119.sql
@@ -1,2 +1,2 @@
--- {"operators": "LIMIT", "complexity": "low", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "OORDER", "refresh_type": "RECOMPUTE"}
+-- {"operators": "LIMIT", "complexity": "low", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "OORDER", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT * FROM OORDER LIMIT 3;

--- a/benchmark/queries/tpcc/query_0120.sql
+++ b/benchmark/queries/tpcc/query_0120.sql
@@ -1,2 +1,2 @@
--- {"operators": "LIMIT", "complexity": "low", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "OORDER", "refresh_type": "RECOMPUTE"}
+-- {"operators": "LIMIT", "complexity": "low", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "OORDER", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT * FROM OORDER LIMIT 4;

--- a/benchmark/queries/tpcc/query_0408.sql
+++ b/benchmark/queries/tpcc/query_0408.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,LIMIT", "complexity": "low", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,LIMIT", "complexity": "low", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, COUNT(*), SUM(W_YTD), AVG(W_TAX) FROM WAREHOUSE GROUP BY W_ID LIMIT 20;

--- a/benchmark/queries/tpcc/query_0415.sql
+++ b/benchmark/queries/tpcc/query_0415.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, COUNT(W_TAX) FROM WAREHOUSE WHERE W_TAX > 0 GROUP BY W_ID HAVING COUNT(W_TAX) < 1 LIMIT 1;

--- a/benchmark/queries/tpcc/query_0417.sql
+++ b/benchmark/queries/tpcc/query_0417.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, SUM(W_TAX) FROM WAREHOUSE WHERE W_TAX > 0 GROUP BY W_ID HAVING SUM(W_TAX) > 0 LIMIT 10;

--- a/benchmark/queries/tpcc/query_0418.sql
+++ b/benchmark/queries/tpcc/query_0418.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, SUM(W_TAX) FROM WAREHOUSE WHERE W_TAX > 0 GROUP BY W_ID HAVING SUM(W_TAX) > 1 LIMIT 10;

--- a/benchmark/queries/tpcc/query_0419.sql
+++ b/benchmark/queries/tpcc/query_0419.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, SUM(W_TAX) FROM WAREHOUSE WHERE W_TAX > 0 GROUP BY W_ID HAVING SUM(W_TAX) < 1 LIMIT 10;

--- a/benchmark/queries/tpcc/query_0421.sql
+++ b/benchmark/queries/tpcc/query_0421.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, MIN(W_TAX) FROM WAREHOUSE WHERE W_TAX > 0 GROUP BY W_ID HAVING MIN(W_TAX) < 1 LIMIT 10;

--- a/benchmark/queries/tpcc/query_0423.sql
+++ b/benchmark/queries/tpcc/query_0423.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, MAX(W_TAX) FROM WAREHOUSE WHERE W_TAX > 0 GROUP BY W_ID HAVING MAX(W_TAX) > 0 LIMIT 5;

--- a/benchmark/queries/tpcc/query_0424.sql
+++ b/benchmark/queries/tpcc/query_0424.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, MAX(W_TAX) FROM WAREHOUSE WHERE W_TAX > 0 GROUP BY W_ID HAVING MAX(W_TAX) < 0 LIMIT 1;

--- a/benchmark/queries/tpcc/query_0425.sql
+++ b/benchmark/queries/tpcc/query_0425.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, MAX(W_TAX) FROM WAREHOUSE WHERE W_TAX > 0 GROUP BY W_ID HAVING MAX(W_TAX) < 1 LIMIT 5;

--- a/benchmark/queries/tpcc/query_0426.sql
+++ b/benchmark/queries/tpcc/query_0426.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, MAX(W_TAX) FROM WAREHOUSE WHERE W_TAX > 0 GROUP BY W_ID HAVING MAX(W_TAX) < 5 LIMIT 5;

--- a/benchmark/queries/tpcc/query_0427.sql
+++ b/benchmark/queries/tpcc/query_0427.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, MAX(W_TAX) FROM WAREHOUSE WHERE W_TAX > 0 GROUP BY W_ID HAVING MAX(W_TAX) < 10 LIMIT 5;

--- a/benchmark/queries/tpcc/query_0428.sql
+++ b/benchmark/queries/tpcc/query_0428.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, COUNT(W_TAX) FROM WAREHOUSE WHERE W_TAX > 1 GROUP BY W_ID HAVING COUNT(W_TAX) > 1 LIMIT 5;

--- a/benchmark/queries/tpcc/query_0429.sql
+++ b/benchmark/queries/tpcc/query_0429.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, COUNT(W_TAX) FROM WAREHOUSE WHERE W_TAX > 1 GROUP BY W_ID HAVING COUNT(W_TAX) < 0 LIMIT 1;

--- a/benchmark/queries/tpcc/query_0430.sql
+++ b/benchmark/queries/tpcc/query_0430.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, COUNT(W_TAX) FROM WAREHOUSE WHERE W_TAX > 1 GROUP BY W_ID HAVING COUNT(W_TAX) < 0 LIMIT 10;

--- a/benchmark/queries/tpcc/query_0431.sql
+++ b/benchmark/queries/tpcc/query_0431.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, AVG(W_TAX) FROM WAREHOUSE WHERE W_TAX > 1 GROUP BY W_ID HAVING AVG(W_TAX) > 5 LIMIT 1;

--- a/benchmark/queries/tpcc/query_0432.sql
+++ b/benchmark/queries/tpcc/query_0432.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, AVG(W_TAX) FROM WAREHOUSE WHERE W_TAX > 1 GROUP BY W_ID HAVING AVG(W_TAX) > 10 LIMIT 1;

--- a/benchmark/queries/tpcc/query_0433.sql
+++ b/benchmark/queries/tpcc/query_0433.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, MIN(W_TAX) FROM WAREHOUSE WHERE W_TAX > 1 GROUP BY W_ID HAVING MIN(W_TAX) < 0 LIMIT 1;

--- a/benchmark/queries/tpcc/query_0434.sql
+++ b/benchmark/queries/tpcc/query_0434.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, MIN(W_TAX) FROM WAREHOUSE WHERE W_TAX > 1 GROUP BY W_ID HAVING MIN(W_TAX) < 1 LIMIT 10;

--- a/benchmark/queries/tpcc/query_0435.sql
+++ b/benchmark/queries/tpcc/query_0435.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, MIN(W_TAX) FROM WAREHOUSE WHERE W_TAX > 1 GROUP BY W_ID HAVING MIN(W_TAX) < 10 LIMIT 10;

--- a/benchmark/queries/tpcc/query_0436.sql
+++ b/benchmark/queries/tpcc/query_0436.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, COUNT(W_TAX) FROM WAREHOUSE WHERE W_TAX > 50 GROUP BY W_ID HAVING COUNT(W_TAX) < 10 LIMIT 5;

--- a/benchmark/queries/tpcc/query_0437.sql
+++ b/benchmark/queries/tpcc/query_0437.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, AVG(W_TAX) FROM WAREHOUSE WHERE W_TAX > 50 GROUP BY W_ID HAVING AVG(W_TAX) > 1 LIMIT 1;

--- a/benchmark/queries/tpcc/query_0438.sql
+++ b/benchmark/queries/tpcc/query_0438.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, AVG(W_TAX) FROM WAREHOUSE WHERE W_TAX > 50 GROUP BY W_ID HAVING AVG(W_TAX) > 5 LIMIT 1;

--- a/benchmark/queries/tpcc/query_0439.sql
+++ b/benchmark/queries/tpcc/query_0439.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, AVG(W_TAX) FROM WAREHOUSE WHERE W_TAX > 50 GROUP BY W_ID HAVING AVG(W_TAX) < 1 LIMIT 1;

--- a/benchmark/queries/tpcc/query_0440.sql
+++ b/benchmark/queries/tpcc/query_0440.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, AVG(W_TAX) FROM WAREHOUSE WHERE W_TAX > 50 GROUP BY W_ID HAVING AVG(W_TAX) < 10 LIMIT 5;

--- a/benchmark/queries/tpcc/query_0441.sql
+++ b/benchmark/queries/tpcc/query_0441.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, MIN(W_TAX) FROM WAREHOUSE WHERE W_TAX > 50 GROUP BY W_ID HAVING MIN(W_TAX) > 5 LIMIT 5;

--- a/benchmark/queries/tpcc/query_0442.sql
+++ b/benchmark/queries/tpcc/query_0442.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, MAX(W_TAX) FROM WAREHOUSE WHERE W_TAX > 50 GROUP BY W_ID HAVING MAX(W_TAX) > 0 LIMIT 1;

--- a/benchmark/queries/tpcc/query_0443.sql
+++ b/benchmark/queries/tpcc/query_0443.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, MAX(W_TAX) FROM WAREHOUSE WHERE W_TAX > 50 GROUP BY W_ID HAVING MAX(W_TAX) < 0 LIMIT 1;

--- a/benchmark/queries/tpcc/query_0444.sql
+++ b/benchmark/queries/tpcc/query_0444.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, MAX(W_TAX) FROM WAREHOUSE WHERE W_TAX > 50 GROUP BY W_ID HAVING MAX(W_TAX) < 0 LIMIT 5;

--- a/benchmark/queries/tpcc/query_0445.sql
+++ b/benchmark/queries/tpcc/query_0445.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, COUNT(W_TAX) FROM WAREHOUSE WHERE W_TAX > 100 GROUP BY W_ID HAVING COUNT(W_TAX) > 0 LIMIT 5;

--- a/benchmark/queries/tpcc/query_0446.sql
+++ b/benchmark/queries/tpcc/query_0446.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, COUNT(W_TAX) FROM WAREHOUSE WHERE W_TAX > 100 GROUP BY W_ID HAVING COUNT(W_TAX) > 1 LIMIT 1;

--- a/benchmark/queries/tpcc/query_0447.sql
+++ b/benchmark/queries/tpcc/query_0447.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, COUNT(W_TAX) FROM WAREHOUSE WHERE W_TAX > 100 GROUP BY W_ID HAVING COUNT(W_TAX) > 5 LIMIT 10;

--- a/benchmark/queries/tpcc/query_0448.sql
+++ b/benchmark/queries/tpcc/query_0448.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, COUNT(W_TAX) FROM WAREHOUSE WHERE W_TAX > 100 GROUP BY W_ID HAVING COUNT(W_TAX) < 5 LIMIT 1;

--- a/benchmark/queries/tpcc/query_0449.sql
+++ b/benchmark/queries/tpcc/query_0449.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, SUM(W_TAX) FROM WAREHOUSE WHERE W_TAX > 100 GROUP BY W_ID HAVING SUM(W_TAX) > 1 LIMIT 5;

--- a/benchmark/queries/tpcc/query_0450.sql
+++ b/benchmark/queries/tpcc/query_0450.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, SUM(W_TAX) FROM WAREHOUSE WHERE W_TAX > 100 GROUP BY W_ID HAVING SUM(W_TAX) > 10 LIMIT 10;

--- a/benchmark/queries/tpcc/query_0451.sql
+++ b/benchmark/queries/tpcc/query_0451.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, SUM(W_TAX) FROM WAREHOUSE WHERE W_TAX > 100 GROUP BY W_ID HAVING SUM(W_TAX) < 1 LIMIT 1;

--- a/benchmark/queries/tpcc/query_0452.sql
+++ b/benchmark/queries/tpcc/query_0452.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, AVG(W_TAX) FROM WAREHOUSE WHERE W_TAX > 100 GROUP BY W_ID HAVING AVG(W_TAX) > 0 LIMIT 1;

--- a/benchmark/queries/tpcc/query_0453.sql
+++ b/benchmark/queries/tpcc/query_0453.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, AVG(W_TAX) FROM WAREHOUSE WHERE W_TAX > 100 GROUP BY W_ID HAVING AVG(W_TAX) > 0 LIMIT 10;

--- a/benchmark/queries/tpcc/query_0454.sql
+++ b/benchmark/queries/tpcc/query_0454.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, AVG(W_TAX) FROM WAREHOUSE WHERE W_TAX > 100 GROUP BY W_ID HAVING AVG(W_TAX) < 0 LIMIT 10;

--- a/benchmark/queries/tpcc/query_0455.sql
+++ b/benchmark/queries/tpcc/query_0455.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, AVG(W_TAX) FROM WAREHOUSE WHERE W_TAX > 100 GROUP BY W_ID HAVING AVG(W_TAX) < 10 LIMIT 10;

--- a/benchmark/queries/tpcc/query_0456.sql
+++ b/benchmark/queries/tpcc/query_0456.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, MIN(W_TAX) FROM WAREHOUSE WHERE W_TAX > 100 GROUP BY W_ID HAVING MIN(W_TAX) > 1 LIMIT 10;

--- a/benchmark/queries/tpcc/query_0457.sql
+++ b/benchmark/queries/tpcc/query_0457.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, MIN(W_TAX) FROM WAREHOUSE WHERE W_TAX > 100 GROUP BY W_ID HAVING MIN(W_TAX) < 0 LIMIT 1;

--- a/benchmark/queries/tpcc/query_0458.sql
+++ b/benchmark/queries/tpcc/query_0458.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, MAX(W_TAX) FROM WAREHOUSE WHERE W_TAX > 100 GROUP BY W_ID HAVING MAX(W_TAX) > 1 LIMIT 1;

--- a/benchmark/queries/tpcc/query_0459.sql
+++ b/benchmark/queries/tpcc/query_0459.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, MAX(W_TAX) FROM WAREHOUSE WHERE W_TAX > 100 GROUP BY W_ID HAVING MAX(W_TAX) > 5 LIMIT 5;

--- a/benchmark/queries/tpcc/query_0460.sql
+++ b/benchmark/queries/tpcc/query_0460.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, MAX(W_TAX) FROM WAREHOUSE WHERE W_TAX > 100 GROUP BY W_ID HAVING MAX(W_TAX) > 10 LIMIT 5;

--- a/benchmark/queries/tpcc/query_0461.sql
+++ b/benchmark/queries/tpcc/query_0461.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, MAX(W_TAX) FROM WAREHOUSE WHERE W_TAX > 100 GROUP BY W_ID HAVING MAX(W_TAX) < 10 LIMIT 5;

--- a/benchmark/queries/tpcc/query_0462.sql
+++ b/benchmark/queries/tpcc/query_0462.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, COUNT(W_TAX) FROM WAREHOUSE WHERE W_TAX < 0 GROUP BY W_ID HAVING COUNT(W_TAX) > 10 LIMIT 10;

--- a/benchmark/queries/tpcc/query_0463.sql
+++ b/benchmark/queries/tpcc/query_0463.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, COUNT(W_TAX) FROM WAREHOUSE WHERE W_TAX < 0 GROUP BY W_ID HAVING COUNT(W_TAX) < 0 LIMIT 1;

--- a/benchmark/queries/tpcc/query_0464.sql
+++ b/benchmark/queries/tpcc/query_0464.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, COUNT(W_TAX) FROM WAREHOUSE WHERE W_TAX < 0 GROUP BY W_ID HAVING COUNT(W_TAX) < 5 LIMIT 5;

--- a/benchmark/queries/tpcc/query_0465.sql
+++ b/benchmark/queries/tpcc/query_0465.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, COUNT(W_TAX) FROM WAREHOUSE WHERE W_TAX < 0 GROUP BY W_ID HAVING COUNT(W_TAX) < 10 LIMIT 10;

--- a/benchmark/queries/tpcc/query_0466.sql
+++ b/benchmark/queries/tpcc/query_0466.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, SUM(W_TAX) FROM WAREHOUSE WHERE W_TAX < 0 GROUP BY W_ID HAVING SUM(W_TAX) > 0 LIMIT 1;

--- a/benchmark/queries/tpcc/query_0467.sql
+++ b/benchmark/queries/tpcc/query_0467.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, SUM(W_TAX) FROM WAREHOUSE WHERE W_TAX < 0 GROUP BY W_ID HAVING SUM(W_TAX) < 5 LIMIT 1;

--- a/benchmark/queries/tpcc/query_0468.sql
+++ b/benchmark/queries/tpcc/query_0468.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, SUM(W_TAX) FROM WAREHOUSE WHERE W_TAX < 0 GROUP BY W_ID HAVING SUM(W_TAX) < 10 LIMIT 5;

--- a/benchmark/queries/tpcc/query_0469.sql
+++ b/benchmark/queries/tpcc/query_0469.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, AVG(W_TAX) FROM WAREHOUSE WHERE W_TAX < 0 GROUP BY W_ID HAVING AVG(W_TAX) > 5 LIMIT 10;

--- a/benchmark/queries/tpcc/query_0470.sql
+++ b/benchmark/queries/tpcc/query_0470.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, MIN(W_TAX) FROM WAREHOUSE WHERE W_TAX < 0 GROUP BY W_ID HAVING MIN(W_TAX) < 5 LIMIT 1;

--- a/benchmark/queries/tpcc/query_0471.sql
+++ b/benchmark/queries/tpcc/query_0471.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, MIN(W_TAX) FROM WAREHOUSE WHERE W_TAX < 0 GROUP BY W_ID HAVING MIN(W_TAX) < 5 LIMIT 5;

--- a/benchmark/queries/tpcc/query_0472.sql
+++ b/benchmark/queries/tpcc/query_0472.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, MIN(W_TAX) FROM WAREHOUSE WHERE W_TAX < 0 GROUP BY W_ID HAVING MIN(W_TAX) < 10 LIMIT 1;

--- a/benchmark/queries/tpcc/query_0473.sql
+++ b/benchmark/queries/tpcc/query_0473.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, MAX(W_TAX) FROM WAREHOUSE WHERE W_TAX < 0 GROUP BY W_ID HAVING MAX(W_TAX) < 5 LIMIT 1;

--- a/benchmark/queries/tpcc/query_0474.sql
+++ b/benchmark/queries/tpcc/query_0474.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, MAX(W_TAX) FROM WAREHOUSE WHERE W_TAX < 0 GROUP BY W_ID HAVING MAX(W_TAX) < 10 LIMIT 10;

--- a/benchmark/queries/tpcc/query_0475.sql
+++ b/benchmark/queries/tpcc/query_0475.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, COUNT(W_TAX) FROM WAREHOUSE WHERE W_TAX < 1 GROUP BY W_ID HAVING COUNT(W_TAX) < 0 LIMIT 1;

--- a/benchmark/queries/tpcc/query_0476.sql
+++ b/benchmark/queries/tpcc/query_0476.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, COUNT(W_TAX) FROM WAREHOUSE WHERE W_TAX < 1 GROUP BY W_ID HAVING COUNT(W_TAX) < 5 LIMIT 10;

--- a/benchmark/queries/tpcc/query_0477.sql
+++ b/benchmark/queries/tpcc/query_0477.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, SUM(W_TAX) FROM WAREHOUSE WHERE W_TAX < 1 GROUP BY W_ID HAVING SUM(W_TAX) > 1 LIMIT 1;

--- a/benchmark/queries/tpcc/query_0478.sql
+++ b/benchmark/queries/tpcc/query_0478.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, SUM(W_TAX) FROM WAREHOUSE WHERE W_TAX < 1 GROUP BY W_ID HAVING SUM(W_TAX) > 5 LIMIT 10;

--- a/benchmark/queries/tpcc/query_0479.sql
+++ b/benchmark/queries/tpcc/query_0479.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, SUM(W_TAX) FROM WAREHOUSE WHERE W_TAX < 1 GROUP BY W_ID HAVING SUM(W_TAX) > 10 LIMIT 10;

--- a/benchmark/queries/tpcc/query_0480.sql
+++ b/benchmark/queries/tpcc/query_0480.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, AVG(W_TAX) FROM WAREHOUSE WHERE W_TAX < 1 GROUP BY W_ID HAVING AVG(W_TAX) > 1 LIMIT 1;

--- a/benchmark/queries/tpcc/query_0481.sql
+++ b/benchmark/queries/tpcc/query_0481.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, AVG(W_TAX) FROM WAREHOUSE WHERE W_TAX < 1 GROUP BY W_ID HAVING AVG(W_TAX) > 10 LIMIT 5;

--- a/benchmark/queries/tpcc/query_0482.sql
+++ b/benchmark/queries/tpcc/query_0482.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, AVG(W_TAX) FROM WAREHOUSE WHERE W_TAX < 1 GROUP BY W_ID HAVING AVG(W_TAX) < 0 LIMIT 10;

--- a/benchmark/queries/tpcc/query_0483.sql
+++ b/benchmark/queries/tpcc/query_0483.sql
@@ -1,2 +1,2 @@
--- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "AGGREGATE,FILTER,LIMIT,HAVING", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT W_ID, MIN(W_TAX) FROM WAREHOUSE WHERE W_TAX < 1 GROUP BY W_ID HAVING MIN(W_TAX) < 1 LIMIT 10;

--- a/benchmark/queries/tpcc/query_0484.sql
+++ b/benchmark/queries/tpcc/query_0484.sql
@@ -1,2 +1,2 @@
--- {"operators": "LIMIT,DISTINCT", "complexity": "low", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "LIMIT,DISTINCT", "complexity": "low", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT DISTINCT W_ID, W_TAX FROM WAREHOUSE LIMIT 10;

--- a/benchmark/queries/tpcc/query_0488.sql
+++ b/benchmark/queries/tpcc/query_0488.sql
@@ -1,2 +1,2 @@
--- {"operators": "LIMIT,DISTINCT", "complexity": "low", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "ORDER_LINE", "refresh_type": "RECOMPUTE"}
+-- {"operators": "LIMIT,DISTINCT", "complexity": "low", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "ORDER_LINE", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT DISTINCT OL_W_ID FROM ORDER_LINE LIMIT 10;

--- a/benchmark/queries/tpcc/query_0492.sql
+++ b/benchmark/queries/tpcc/query_0492.sql
@@ -1,2 +1,2 @@
--- {"operators": "OUTER_JOIN,AGGREGATE,LIMIT", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE,DISTRICT", "refresh_type": "RECOMPUTE"}
+-- {"operators": "OUTER_JOIN,AGGREGATE,LIMIT", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE,DISTRICT", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT WAREHOUSE.W_ID, COUNT(*) FROM WAREHOUSE LEFT JOIN DISTRICT ON WAREHOUSE.W_ID = DISTRICT.D_W_ID GROUP BY WAREHOUSE.W_ID LIMIT 10;

--- a/benchmark/queries/tpcc/query_0495.sql
+++ b/benchmark/queries/tpcc/query_0495.sql
@@ -1,2 +1,2 @@
--- {"operators": "OUTER_JOIN,AGGREGATE,LIMIT", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE,STOCK", "refresh_type": "RECOMPUTE"}
+-- {"operators": "OUTER_JOIN,AGGREGATE,LIMIT", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "WAREHOUSE,STOCK", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT WAREHOUSE.W_ID, COUNT(*) FROM WAREHOUSE LEFT JOIN STOCK ON WAREHOUSE.W_ID = STOCK.S_W_ID GROUP BY WAREHOUSE.W_ID LIMIT 10;

--- a/benchmark/queries/tpcc/query_1566.sql
+++ b/benchmark/queries/tpcc/query_1566.sql
@@ -1,2 +1,2 @@
--- {"operators": "LIMIT", "complexity": "low", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "ITEM", "refresh_type": "RECOMPUTE"}
+-- {"operators": "LIMIT", "complexity": "low", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "ITEM", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT I_ID, I_NAME, REGEXP_MATCHES(I_NAME, '[A-Z]+') AS matches FROM ITEM LIMIT 50;

--- a/benchmark/queries/tpcc/query_1989.sql
+++ b/benchmark/queries/tpcc/query_1989.sql
@@ -1,2 +1,2 @@
--- {"operators": "CROSS_JOIN,FILTER,LIMIT", "complexity": "medium", "is_incremental": true, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "CUSTOMER,ITEM", "refresh_type": "RECOMPUTE"}
+-- {"operators": "CROSS_JOIN,FILTER,LIMIT", "complexity": "medium", "is_incremental": false, "has_nulls": false, "has_cast": false, "has_case": false, "tables": "CUSTOMER,ITEM", "refresh_type": "FULL_REFRESH", "mv_verified": true}
 SELECT c.C_W_ID, c.C_ID, c.C_LAST, i.I_NAME FROM CUSTOMER c CROSS JOIN ITEM i WHERE c.C_LAST LIKE SUBSTRING(i.I_NAME FROM 1 FOR 1) || '%' LIMIT 100;

--- a/src/core/incremental_checker.cpp
+++ b/src/core/incremental_checker.cpp
@@ -140,8 +140,8 @@ static void MergeCompatibilityAndNonLocalFacts(PlanAnalysis &result, const PlanA
 	result.found_sample = result.found_sample || body.found_sample;
 }
 
-/// Single-pass recursive plan analysis: validates IVM compatibility AND extracts metadata.
-static void AnalyzeNode(LogicalOperator *node, PlanAnalysis &result) {
+void AnalyzePlanOperator(LogicalOperator &op, PlanAnalysis &result) {
+	auto *node = &op;
 	switch (node->type) {
 	// Infrastructure nodes — always compatible, no metadata
 	case LogicalOperatorType::LOGICAL_CREATE_TABLE:
@@ -162,23 +162,7 @@ static void AnalyzeNode(LogicalOperator *node, PlanAnalysis &result) {
 		break;
 
 	case LogicalOperatorType::LOGICAL_MATERIALIZED_CTE:
-		// After the parser runs CTEInlining (with CTE_MATERIALIZE_ALWAYS → DEFAULT), most
-		// query-bound CTEs get inlined into the outer plan. Any MATERIALIZED_CTE remaining
-		// here couldn't be inlined (recursive, multi-ref with aggregate, etc.). Analyze
-		// the outer first; inherit the CTE body's aggregate only when the outer is a pure
-		// pass-through, otherwise classify from the outer alone.
-		if (node->children.size() >= 2) {
-			AnalyzeNode(node->children[1].get(), result);
-			const bool outer_passthrough = !result.found_aggregation && !result.found_distinct && !result.found_join;
-			if (outer_passthrough) {
-				AnalyzeNode(node->children[0].get(), result);
-			} else {
-				PlanAnalysis body_analysis;
-				AnalyzeNode(node->children[0].get(), body_analysis);
-				MergeCompatibilityAndNonLocalFacts(result, body_analysis);
-			}
-		}
-		return;
+		break;
 
 	case LogicalOperatorType::LOGICAL_FILTER:
 		// Check for volatile functions
@@ -449,10 +433,7 @@ static void AnalyzeNode(LogicalOperator *node, PlanAnalysis &result) {
 			result.incremental_compatible = false; // non-column ORDER BY: fall through to FULL_REFRESH
 			result.found_unsupported_order_by = true;
 		}
-		if (!node->children.empty()) {
-			AnalyzeNode(node->children[0].get(), result);
-		}
-		return;
+		break;
 	}
 
 	case LogicalOperatorType::LOGICAL_ORDER_BY: {
@@ -465,10 +446,7 @@ static void AnalyzeNode(LogicalOperator *node, PlanAnalysis &result) {
 		if (result.top_k_order_columns.empty()) {
 			(void)ExtractOrderBy(order.orders, result);
 		}
-		if (!node->children.empty()) {
-			AnalyzeNode(node->children[0].get(), result);
-		}
-		return;
+		break;
 	}
 
 	case LogicalOperatorType::LOGICAL_LIMIT: {
@@ -492,10 +470,7 @@ static void AnalyzeNode(LogicalOperator *node, PlanAnalysis &result) {
 				result.top_k_offset = limit_node->offset_val.GetConstantValue();
 			}
 		}
-		if (!node->children.empty()) {
-			AnalyzeNode(node->children[0].get(), result);
-		}
-		return;
+		break;
 	}
 
 	default:
@@ -504,16 +479,78 @@ static void AnalyzeNode(LogicalOperator *node, PlanAnalysis &result) {
 		result.found_unsupported_operator = true;
 		break;
 	}
+}
 
-	for (auto &child : node->children) {
-		AnalyzeNode(child.get(), result);
+static void MergeWindowAnalysis(PlanAnalysis &result, PlanAnalysis &body) {
+	if (!body.found_window) {
+		return;
+	}
+	if (!result.found_window) {
+		result.window_partition_columns = std::move(body.window_partition_columns);
+		result.window_partition_column_indexes = std::move(body.window_partition_column_indexes);
+		result.window_order_columns = std::move(body.window_order_columns);
+		result.window_row_key_compatible = body.window_row_key_compatible;
+		return;
+	}
+	bool compatible = result.window_row_key_compatible && body.window_row_key_compatible &&
+	                  SameWindowColumns(result.window_partition_columns, body.window_partition_columns) &&
+	                  SameWindowColumns(result.window_order_columns, body.window_order_columns);
+	for (idx_t i = 0; i < body.window_partition_columns.size(); i++) {
+		auto &column = body.window_partition_columns[i];
+		if (std::find(result.window_partition_columns.begin(), result.window_partition_columns.end(), column) ==
+		    result.window_partition_columns.end()) {
+			result.window_partition_columns.push_back(std::move(column));
+			result.window_partition_column_indexes.push_back(body.window_partition_column_indexes[i]);
+		}
+	}
+	result.window_row_key_compatible = compatible;
+	if (!compatible) {
+		result.window_order_columns.clear();
 	}
 }
 
-PlanAnalysis AnalyzePlan(LogicalOperator *plan) {
-	PlanAnalysis result;
-	AnalyzeNode(plan, result);
-	return result;
+void MergeMaterializedCteBodyAnalysis(PlanAnalysis &result, PlanAnalysis body) {
+	const bool outer_passthrough = !result.found_aggregation && !result.found_distinct && !result.found_join;
+	if (!outer_passthrough) {
+		MergeCompatibilityAndNonLocalFacts(result, body);
+		return;
+	}
+
+	MergeCompatibilityAndNonLocalFacts(result, body);
+	MergeWindowAnalysis(result, body);
+	result.found_aggregation = result.found_aggregation || body.found_aggregation;
+	result.found_projection = result.found_projection || body.found_projection;
+	result.found_having = result.found_having || body.found_having;
+	result.found_distinct = result.found_distinct || body.found_distinct;
+	result.found_union_distinct = result.found_union_distinct || body.found_union_distinct;
+	result.found_minmax = result.found_minmax || body.found_minmax;
+	result.found_list = result.found_list || body.found_list;
+	result.found_filtered_list = result.found_filtered_list || body.found_filtered_list;
+	result.found_left_join = result.found_left_join || body.found_left_join;
+	result.found_full_outer = result.found_full_outer || body.found_full_outer;
+	result.found_semi_anti_join = result.found_semi_anti_join || body.found_semi_anti_join;
+	result.found_join = result.found_join || body.found_join;
+	result.found_delim_join = result.found_delim_join || body.found_delim_join;
+	result.found_single_join = result.found_single_join || body.found_single_join;
+	result.found_window = result.found_window || body.found_window;
+	result.found_top_k = result.found_top_k || body.found_top_k;
+	result.found_count_distinct = result.found_count_distinct || body.found_count_distinct;
+	result.found_grouping_sets = result.found_grouping_sets || body.found_grouping_sets;
+	result.found_nested_aggregate = result.found_nested_aggregate || body.found_nested_aggregate;
+	if (body.found_top_k) {
+		result.top_k_limit = body.top_k_limit;
+		result.top_k_offset = body.top_k_offset;
+		result.top_k_order_columns = std::move(body.top_k_order_columns);
+		result.top_k_order_desc = std::move(body.top_k_order_desc);
+	} else if (result.top_k_order_columns.empty()) {
+		result.top_k_order_columns = std::move(body.top_k_order_columns);
+		result.top_k_order_desc = std::move(body.top_k_order_desc);
+	}
+	D_ASSERT(result.aggregate_columns.empty());
+	result.aggregate_columns = std::move(body.aggregate_columns);
+	result.aggregate_types = std::move(body.aggregate_types);
+	result.group_count = body.group_count;
+	result.group_index = body.group_index;
 }
 
 } // namespace duckdb

--- a/src/core/incremental_checker.cpp
+++ b/src/core/incremental_checker.cpp
@@ -516,8 +516,4 @@ PlanAnalysis AnalyzePlan(LogicalOperator *plan) {
 	return result;
 }
 
-bool ValidateIncrementalPlan(LogicalOperator *plan) {
-	return AnalyzePlan(plan).incremental_compatible;
-}
-
 } // namespace duckdb

--- a/src/core/incremental_checker.cpp
+++ b/src/core/incremental_checker.cpp
@@ -15,8 +15,6 @@
 #include "duckdb/planner/operator/logical_window.hpp"
 #include "duckdb/planner/expression/bound_window_expression.hpp"
 #include "duckdb/planner/operator/logical_top_n.hpp"
-#include "duckdb/planner/operator/logical_limit.hpp"
-#include "duckdb/planner/operator/logical_order.hpp"
 #include "duckdb/planner/operator/logical_set_operation.hpp"
 #include "duckdb/planner/operator/logical_unnest.hpp"
 
@@ -31,28 +29,12 @@ static const unordered_set<string> &GetSupportedAggregates() {
 	return kSet;
 }
 
-/// Extract a column name from an ORDER BY expression. Returns empty if the expression
-/// isn't a column reference (rejecting non-column ORDER BY in Phase 1 keeps the new-top-k
-/// SQL emission simple — function/CASE/cast expressions over base columns would need a
-/// projection alias).
-static string OrderByColumnName(const Expression &expr) {
-	if (expr.type == ExpressionType::BOUND_COLUMN_REF) {
-		auto &bcr = expr.Cast<BoundColumnRefExpression>();
-		if (!bcr.alias.empty()) {
-			return bcr.alias;
-		}
-		return bcr.GetName();
-	}
-	return string();
-}
-
-static bool WindowColumn(const Expression &expr, string &name, idx_t &column_index) {
+static bool WindowColumn(const Expression &expr, string &name) {
 	if (expr.type != ExpressionType::BOUND_COLUMN_REF) {
 		return false;
 	}
 	auto &column = expr.Cast<BoundColumnRefExpression>();
 	name = column.alias.empty() ? column.GetName() : column.alias;
-	column_index = column.binding.column_index;
 	return !name.empty();
 }
 
@@ -68,18 +50,15 @@ static bool SameWindowColumns(const vector<string> &left, const vector<string> &
 	return true;
 }
 
-/// Populate top_k_order_columns / top_k_order_desc from a vector<BoundOrderByNode>.
-/// Returns false if any entry is non-column-ref (caller should mark incremental_compatible=false).
-static bool ExtractOrderBy(const vector<BoundOrderByNode> &orders, PlanAnalysis &result) {
-	result.top_k_order_columns.clear();
-	result.top_k_order_desc.clear();
-	for (auto &o : orders) {
-		string name = OrderByColumnName(*o.expression);
-		if (name.empty()) {
+static bool HasSimpleOrderBy(const vector<BoundOrderByNode> &orders) {
+	for (auto &order : orders) {
+		if (order.expression->type != ExpressionType::BOUND_COLUMN_REF) {
 			return false;
 		}
-		result.top_k_order_columns.push_back(name);
-		result.top_k_order_desc.push_back(o.type == OrderType::DESCENDING);
+		auto &column = order.expression->Cast<BoundColumnRefExpression>();
+		if (column.alias.empty() && column.GetName().empty()) {
+			return false;
+		}
 	}
 	return true;
 }
@@ -152,6 +131,7 @@ void AnalyzePlanOperator(LogicalOperator &op, PlanAnalysis &result) {
 	case LogicalOperatorType::LOGICAL_CHUNK_GET:
 	case LogicalOperatorType::LOGICAL_DELIM_GET:
 	case LogicalOperatorType::LOGICAL_CTE_REF:
+	case LogicalOperatorType::LOGICAL_ORDER_BY:
 		break;
 
 	case LogicalOperatorType::LOGICAL_UNNEST:
@@ -375,8 +355,7 @@ void AnalyzePlanOperator(LogicalOperator &op, PlanAnalysis &result) {
 				vector<string> current_orders;
 				for (auto &part : win_expr.partitions) {
 					string col_name;
-					idx_t col_index = DConstants::INVALID_INDEX;
-					if (!WindowColumn(*part, col_name, col_index)) {
+					if (!WindowColumn(*part, col_name)) {
 						result.window_row_key_compatible = false;
 						col_name = part->GetName();
 					}
@@ -391,13 +370,11 @@ void AnalyzePlanOperator(LogicalOperator &op, PlanAnalysis &result) {
 					}
 					if (!found) {
 						result.window_partition_columns.push_back(col_name);
-						result.window_partition_column_indexes.push_back(col_index);
 					}
 				}
 				for (auto &order : win_expr.orders) {
 					string col_name;
-					idx_t col_index = DConstants::INVALID_INDEX;
-					if (!WindowColumn(*order.expression, col_name, col_index)) {
+					if (!WindowColumn(*order.expression, col_name)) {
 						result.window_row_key_compatible = false;
 						break;
 					}
@@ -424,35 +401,17 @@ void AnalyzePlanOperator(LogicalOperator &op, PlanAnalysis &result) {
 	}
 
 	case LogicalOperatorType::LOGICAL_TOP_N: {
-		// TOP_N fuses ORDER BY + LIMIT. Capture both for top-k suffix handling.
+		// Function/CASE/cast order expressions need a projection alias before they can
+		// be emitted in the user-facing top-k view.
 		auto &top_n = node->Cast<LogicalTopN>();
-		result.found_top_k = true;
-		result.top_k_limit = top_n.limit;
-		result.top_k_offset = top_n.offset;
-		if (!ExtractOrderBy(top_n.orders, result)) {
+		if (!HasSimpleOrderBy(top_n.orders)) {
 			result.incremental_compatible = false; // non-column ORDER BY: fall through to FULL_REFRESH
 			result.found_unsupported_order_by = true;
 		}
 		break;
 	}
 
-	case LogicalOperatorType::LOGICAL_ORDER_BY: {
-		// ORDER BY alone (without LIMIT) is meaningless on an MV (a table has no inherent
-		// order). Top-k delta compilation drops the node from the delta plan; we still capture
-		// the order columns so a sibling LIMIT below this node — see plan shapes where
-		// LPTS keeps them as separate ORDER_BY → LIMIT nodes — has them available for
-		// top-k suffix handling.
-		auto &order = node->Cast<LogicalOrder>();
-		if (result.top_k_order_columns.empty()) {
-			(void)ExtractOrderBy(order.orders, result);
-		}
-		break;
-	}
-
 	case LogicalOperatorType::LOGICAL_LIMIT: {
-		// LPTS disables the top_n optimizer so ORDER BY + LIMIT appear as separate nodes.
-		// LIMIT is what makes a query top-k; ORDER BY alone does not.
-		result.found_top_k = true;
 		// Ordered top-k is maintained over an unlimited backing table and the
 		// ORDER BY/LIMIT is applied by the user-facing view. A standalone LIMIT
 		// remains in the backing-table plan; maintaining only its current rows
@@ -460,15 +419,6 @@ void AnalyzePlanOperator(LogicalOperator &op, PlanAnalysis &result) {
 		if (node->children.empty() || node->children[0]->type != LogicalOperatorType::LOGICAL_ORDER_BY) {
 			result.incremental_compatible = false;
 			result.found_unsupported_operator = true;
-		}
-		auto *limit_node = dynamic_cast<LogicalLimit *>(node);
-		if (limit_node) {
-			if (limit_node->limit_val.Type() == LimitNodeType::CONSTANT_VALUE) {
-				result.top_k_limit = limit_node->limit_val.GetConstantValue();
-			}
-			if (limit_node->offset_val.Type() == LimitNodeType::CONSTANT_VALUE) {
-				result.top_k_offset = limit_node->offset_val.GetConstantValue();
-			}
 		}
 		break;
 	}
@@ -487,7 +437,6 @@ static void MergeWindowAnalysis(PlanAnalysis &result, PlanAnalysis &body) {
 	}
 	if (!result.found_window) {
 		result.window_partition_columns = std::move(body.window_partition_columns);
-		result.window_partition_column_indexes = std::move(body.window_partition_column_indexes);
 		result.window_order_columns = std::move(body.window_order_columns);
 		result.window_row_key_compatible = body.window_row_key_compatible;
 		return;
@@ -495,12 +444,10 @@ static void MergeWindowAnalysis(PlanAnalysis &result, PlanAnalysis &body) {
 	bool compatible = result.window_row_key_compatible && body.window_row_key_compatible &&
 	                  SameWindowColumns(result.window_partition_columns, body.window_partition_columns) &&
 	                  SameWindowColumns(result.window_order_columns, body.window_order_columns);
-	for (idx_t i = 0; i < body.window_partition_columns.size(); i++) {
-		auto &column = body.window_partition_columns[i];
+	for (auto &column : body.window_partition_columns) {
 		if (std::find(result.window_partition_columns.begin(), result.window_partition_columns.end(), column) ==
 		    result.window_partition_columns.end()) {
 			result.window_partition_columns.push_back(std::move(column));
-			result.window_partition_column_indexes.push_back(body.window_partition_column_indexes[i]);
 		}
 	}
 	result.window_row_key_compatible = compatible;
@@ -533,19 +480,9 @@ void MergeMaterializedCteBodyAnalysis(PlanAnalysis &result, PlanAnalysis body) {
 	result.found_delim_join = result.found_delim_join || body.found_delim_join;
 	result.found_single_join = result.found_single_join || body.found_single_join;
 	result.found_window = result.found_window || body.found_window;
-	result.found_top_k = result.found_top_k || body.found_top_k;
 	result.found_count_distinct = result.found_count_distinct || body.found_count_distinct;
 	result.found_grouping_sets = result.found_grouping_sets || body.found_grouping_sets;
 	result.found_nested_aggregate = result.found_nested_aggregate || body.found_nested_aggregate;
-	if (body.found_top_k) {
-		result.top_k_limit = body.top_k_limit;
-		result.top_k_offset = body.top_k_offset;
-		result.top_k_order_columns = std::move(body.top_k_order_columns);
-		result.top_k_order_desc = std::move(body.top_k_order_desc);
-	} else if (result.top_k_order_columns.empty()) {
-		result.top_k_order_columns = std::move(body.top_k_order_columns);
-		result.top_k_order_desc = std::move(body.top_k_order_desc);
-	}
 	D_ASSERT(result.aggregate_columns.empty());
 	result.aggregate_columns = std::move(body.aggregate_columns);
 	result.aggregate_types = std::move(body.aggregate_types);

--- a/src/core/ivm_view_classifier.cpp
+++ b/src/core/ivm_view_classifier.cpp
@@ -209,7 +209,7 @@ static bool GroupColumnsAreVisibleOutputs(const vector<string> &group_columns, c
 static void AddJoinKeyGroupColumns(const CreateMVPlanFacts &facts, const vector<string> &output_names,
                                    vector<string> &aggregate_columns, vector<DeltaStrategyReason> &strategy_reasons) {
 	auto *top_proj_ptr = facts.first_projection;
-	auto *cjoin = facts.first_comparison_join;
+	auto *cjoin = facts.comparison_joins.empty() ? nullptr : facts.comparison_joins.front();
 	if (!top_proj_ptr || !cjoin) {
 		return;
 	}

--- a/src/core/parser.cpp
+++ b/src/core/parser.cpp
@@ -421,7 +421,7 @@ MaterializedViewParserExtension::PlanFunction(ParserExtensionInfo *info, ClientC
 	add_create_profile_step("create_compile_full_plan", full_plan_start);
 
 	// Inline CTEs so create-MV facts see the folded structure.
-	InlineCtesIfPresent(context, *planner.binder, plan);
+	(void)InlineCtesIfPresent(context, *planner.binder, plan);
 
 	// Plan the raw SELECT query separately for IVM plan rewrite + LPTS conversion
 	vector<string> output_names;
@@ -453,9 +453,8 @@ MaterializedViewParserExtension::PlanFunction(ParserExtensionInfo *info, ClientC
 		// Inline CTEs without running the full optimizer, which can reshape plans
 		// before OpenIVM's structural rewrites.
 		auto select_rewrite_start = create_profile_now();
-		InlineCtesIfPresent(context, *select_planner.binder, select_plan);
-		auto pre_rewrite_facts = BuildCreateMVPlanFacts(select_plan.get(), current_catalog);
-		pre_rewrite_has_aggregate_filter = pre_rewrite_facts.has_bound_aggregate_filter;
+		pre_rewrite_has_aggregate_filter =
+		    InlineCtesIfPresent(context, *select_planner.binder, select_plan);
 
 		// Apply IVM plan rewrites (DISTINCT → GROUP BY + COUNT, AVG → SUM + COUNT, LEFT JOIN key)
 		PlanRewrite(context, *select_planner.binder, select_plan, select_planner.names);

--- a/src/core/parser.cpp
+++ b/src/core/parser.cpp
@@ -557,7 +557,7 @@ MaterializedViewParserExtension::PlanFunction(ParserExtensionInfo *info, ClientC
 			                    "original query: %s\n",
 			                    view_query.c_str());
 		}
-		if (PlanNeedsOriginalSqlForLpts(select_plan.get())) {
+		if (PlanNeedsOriginalSqlForLpts(post_rewrite_facts)) {
 			view_query = original_view_query;
 			lpts_fallback = true;
 			OPENIVM_DEBUG_PRINT("[CREATE MV] LPTS can't round-trip this construct — "
@@ -813,12 +813,12 @@ MaterializedViewParserExtension::PlanFunction(ParserExtensionInfo *info, ClientC
 				distinct_extracted_filter = std::move(d_filter);
 			}
 		}
-		// Walk the rewritten plan for the outer aggregate's expressions. v0 supports
+		// Inspect the outer aggregate collected by the existing plan-facts walk. v0 supports
 		// exactly one SUM(<arg>) — `openivm_count_star` (auto-injected by PlanRewrite)
 		// is allowed alongside it. Anything else (AVG, COUNT, MIN/MAX, multiple SUMs)
 		// demotes back to GROUP_RECOMPUTE.
 		if (!distinct_extracted_cols.empty()) {
-			LogicalAggregate *outer_agg = FindOuterAggregate(plan.get());
+			LogicalAggregate *outer_agg = facts.aggregates.empty() ? nullptr : facts.aggregates.front();
 			int sum_count = 0;
 			bool unsupported_agg = false;
 			if (outer_agg) {

--- a/src/core/parser.cpp
+++ b/src/core/parser.cpp
@@ -453,8 +453,7 @@ MaterializedViewParserExtension::PlanFunction(ParserExtensionInfo *info, ClientC
 		// Inline CTEs without running the full optimizer, which can reshape plans
 		// before OpenIVM's structural rewrites.
 		auto select_rewrite_start = create_profile_now();
-		pre_rewrite_has_aggregate_filter =
-		    InlineCtesIfPresent(context, *select_planner.binder, select_plan);
+		pre_rewrite_has_aggregate_filter = InlineCtesIfPresent(context, *select_planner.binder, select_plan);
 
 		// Apply IVM plan rewrites (DISTINCT → GROUP BY + COUNT, AVG → SUM + COUNT, LEFT JOIN key)
 		PlanRewrite(context, *select_planner.binder, select_plan, select_planner.names);

--- a/src/core/parser_plan_helpers.cpp
+++ b/src/core/parser_plan_helpers.cpp
@@ -321,6 +321,11 @@ static string CollectCreateMVPlanFacts(LogicalOperator *op, const string &curren
 		return "";
 	}
 	AnalyzePlanOperator(*op, analysis);
+	auto *logical_join = dynamic_cast<LogicalJoin *>(op);
+	if (logical_join && (logical_join->join_type == JoinType::LEFT || logical_join->join_type == JoinType::RIGHT ||
+	                     logical_join->join_type == JoinType::OUTER)) {
+		facts.outer_join_count++;
+	}
 	if (redundant_distinct && op != redundant_distinct && op->type == LogicalOperatorType::LOGICAL_DISTINCT) {
 		facts.has_descendant_distinct = true;
 	}
@@ -329,7 +334,6 @@ static string CollectCreateMVPlanFacts(LogicalOperator *op, const string &curren
 		seen_agg_above = true;
 		auto &agg = op->Cast<LogicalAggregate>();
 		facts.aggregates.push_back(&agg);
-		facts.has_bound_aggregate_filter = facts.has_bound_aggregate_filter || HasBoundAggregateFilter(agg);
 	} else if (op->type == LogicalOperatorType::LOGICAL_UNION) {
 		if (!seen_agg_above) {
 			facts.has_union_before_aggregate = true;
@@ -341,14 +345,17 @@ static string CollectCreateMVPlanFacts(LogicalOperator *op, const string &curren
 	} else if (op->type == LogicalOperatorType::LOGICAL_PIVOT) {
 		facts.has_pivot = true;
 	}
-	if (op->type == LogicalOperatorType::LOGICAL_FILTER && !op->children.empty()) {
-		auto *filter_input = op->children[0].get();
-		while (filter_input && filter_input->type == LogicalOperatorType::LOGICAL_PROJECTION &&
-		       filter_input->children.size() == 1) {
-			filter_input = filter_input->children[0].get();
-		}
-		if (filter_input && filter_input->type == LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY) {
-			facts.has_filter_above_aggregate = true;
+	if (op->type == LogicalOperatorType::LOGICAL_FILTER) {
+		facts.has_cardinality_changing_filter = true;
+		if (!op->children.empty()) {
+			auto *filter_input = op->children[0].get();
+			while (filter_input && filter_input->type == LogicalOperatorType::LOGICAL_PROJECTION &&
+			       filter_input->children.size() == 1) {
+				filter_input = filter_input->children[0].get();
+			}
+			if (filter_input && filter_input->type == LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY) {
+				facts.has_filter_above_aggregate = true;
+			}
 		}
 	}
 	if (op->type == LogicalOperatorType::LOGICAL_COMPARISON_JOIN ||
@@ -367,11 +374,6 @@ static string CollectCreateMVPlanFacts(LogicalOperator *op, const string &curren
 	           op->type == LogicalOperatorType::LOGICAL_ASOF_JOIN ||
 	           op->type == LogicalOperatorType::LOGICAL_DELIM_JOIN) {
 		auto &join = op->Cast<LogicalComparisonJoin>();
-		if ((op->type == LogicalOperatorType::LOGICAL_COMPARISON_JOIN ||
-		     op->type == LogicalOperatorType::LOGICAL_ASOF_JOIN) &&
-		    !facts.first_comparison_join) {
-			facts.first_comparison_join = &join;
-		}
 		if (op->type == LogicalOperatorType::LOGICAL_COMPARISON_JOIN ||
 		    op->type == LogicalOperatorType::LOGICAL_ASOF_JOIN) {
 			facts.comparison_joins.push_back(&join);
@@ -405,6 +407,8 @@ static string CollectCreateMVPlanFacts(LogicalOperator *op, const string &curren
 		}
 	} else if (op->type == LogicalOperatorType::LOGICAL_GET) {
 		auto &get = op->Cast<LogicalGet>();
+		facts.has_cardinality_changing_filter =
+		    facts.has_cardinality_changing_filter || !get.table_filters.filters.empty();
 		AddGetFacts(get, current_catalog, facts, next_occurrence);
 		auto table_ref = get.GetTable();
 		if (table_ref.get()) {
@@ -1263,24 +1267,7 @@ bool BuildProjectionKeyLineage(const CreateMVPlanFacts &facts, const vector<stri
 	return false;
 }
 
-static idx_t CountOuterJoins(const LogicalOperator *node) {
-	if (!node) {
-		return 0;
-	}
-	idx_t count = 0;
-	auto *join = dynamic_cast<const LogicalJoin *>(node);
-	if (join && (join->join_type == JoinType::LEFT || join->join_type == JoinType::RIGHT ||
-	             join->join_type == JoinType::OUTER)) {
-		count++;
-	}
-	for (auto &child : node->children) {
-		count += CountOuterJoins(child.get());
-	}
-	return count;
-}
-
 bool BuildLeftJoinKeySource(const CreateMVPlanFacts &facts, RefreshMetadata::LeftJoinKeySource &out) {
-	auto outer_join_count = CountOuterJoins(facts.root);
 	for (auto *join : facts.comparison_joins) {
 		if (!join || join->join_type != JoinType::LEFT || join->conditions.empty()) {
 			continue;
@@ -1296,7 +1283,7 @@ bool BuildLeftJoinKeySource(const CreateMVPlanFacts &facts, RefreshMetadata::Lef
 		out.table = source.table;
 		out.occurrence = source.occurrence;
 		out.column = source.column;
-		out.cardinality_transition_check_safe = outer_join_count == 1 && join->conditions.size() == 1 &&
+		out.cardinality_transition_check_safe = facts.outer_join_count == 1 && join->conditions.size() == 1 &&
 		                                        join->conditions[0].comparison == ExpressionType::COMPARE_EQUAL;
 		return true;
 	}
@@ -2147,24 +2134,6 @@ static bool IsUnfilteredGetSubtree(LogicalOperator *op) {
 	return op && op->type == LogicalOperatorType::LOGICAL_GET && op->Cast<LogicalGet>().table_filters.filters.empty();
 }
 
-static bool ContainsCardinalityChangingFilter(LogicalOperator *op) {
-	if (!op) {
-		return false;
-	}
-	if (op->type == LogicalOperatorType::LOGICAL_FILTER) {
-		return true;
-	}
-	if (op->type == LogicalOperatorType::LOGICAL_GET && !op->Cast<LogicalGet>().table_filters.filters.empty()) {
-		return true;
-	}
-	for (auto &child : op->children) {
-		if (ContainsCardinalityChangingFilter(child.get())) {
-			return true;
-		}
-	}
-	return false;
-}
-
 static bool ColumnIsNotNull(LogicalGet &get, const string &column_name) {
 	auto table = get.GetTable();
 	if (!table.get() || !table.get()->ColumnExists(column_name)) {
@@ -2197,7 +2166,7 @@ static string BuildLeftJoinSecondaryForLevel(ClientContext &context, const Creat
 	// LogicalFilter above the join. Inspect the complete view plan as well as
 	// the local children; secondary transition counts are valid only when no
 	// additional cardinality predicate exists anywhere in this aggregate view.
-	if (ContainsCardinalityChangingFilter(facts.root)) {
+	if (facts.has_cardinality_changing_filter) {
 		return "";
 	}
 	// __newc below counts rows directly in the inner base table. A filter or any other

--- a/src/core/parser_plan_helpers.cpp
+++ b/src/core/parser_plan_helpers.cpp
@@ -434,7 +434,7 @@ static string CollectCreateMVPlanFacts(LogicalOperator *op, const string &curren
 	}
 	auto collect_child = [&](LogicalOperator *child, PlanAnalysis &child_analysis) {
 		string child_first = CollectCreateMVPlanFacts(child, current_catalog, facts, next_occurrence, seen_agg_above,
-		                                             under_join, redundant_distinct, child_analysis);
+		                                              under_join, redundant_distinct, child_analysis);
 		if (first_table.empty()) {
 			first_table = std::move(child_first);
 		}
@@ -1487,8 +1487,7 @@ static void CollectWindowJoinEdges(LogicalComparisonJoin &join, const CreateMVPl
 		}
 		OccurrenceColumnRef left_ref, right_ref;
 		if (!ResolveBindingToOccurrenceRefWithCast(left->binding, facts, left_ref, left_cast, left->return_type) ||
-		    !ResolveBindingToOccurrenceRefWithCast(right->binding, facts, right_ref, right_cast,
-		                                           right->return_type)) {
+		    !ResolveBindingToOccurrenceRefWithCast(right->binding, facts, right_ref, right_cast, right->return_type)) {
 			continue;
 		}
 		switch (join.join_type) {

--- a/src/core/parser_plan_helpers.cpp
+++ b/src/core/parser_plan_helpers.cpp
@@ -68,11 +68,25 @@ string BuildTopKSuffix(const vector<BoundOrderByNode> &orders, idx_t limit_val, 
 	return sql;
 }
 
-static bool PrepareCtesForInlining(LogicalOperator *op) {
+static bool HasBoundAggregateFilter(LogicalAggregate &aggregate) {
+	for (auto &expression : aggregate.expressions) {
+		if (expression->expression_class == ExpressionClass::BOUND_AGGREGATE &&
+		    expression->Cast<BoundAggregateExpression>().filter) {
+			return true;
+		}
+	}
+	return false;
+}
+
+static bool PrepareCtesForInlining(LogicalOperator *op, bool &has_bound_aggregate_filter) {
 	if (!op) {
 		return false;
 	}
 	bool found_cte = op->type == LogicalOperatorType::LOGICAL_CTE_REF;
+	if (op->type == LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY &&
+	    HasBoundAggregateFilter(op->Cast<LogicalAggregate>())) {
+		has_bound_aggregate_filter = true;
+	}
 	if (op->type == LogicalOperatorType::LOGICAL_MATERIALIZED_CTE) {
 		found_cte = true;
 		auto &cte = op->Cast<LogicalMaterializedCTE>();
@@ -81,18 +95,19 @@ static bool PrepareCtesForInlining(LogicalOperator *op) {
 		}
 	}
 	for (auto &child : op->children) {
-		found_cte = PrepareCtesForInlining(child.get()) || found_cte;
+		found_cte = PrepareCtesForInlining(child.get(), has_bound_aggregate_filter) || found_cte;
 	}
 	return found_cte;
 }
 
-void InlineCtesIfPresent(ClientContext &context, Binder &binder, unique_ptr<LogicalOperator> &plan) {
-	if (!PrepareCtesForInlining(plan.get())) {
-		return;
+bool InlineCtesIfPresent(ClientContext &context, Binder &binder, unique_ptr<LogicalOperator> &plan) {
+	bool has_bound_aggregate_filter = false;
+	if (PrepareCtesForInlining(plan.get(), has_bound_aggregate_filter)) {
+		Optimizer cte_opt(binder, context);
+		CTEInlining cte_inlining(cte_opt);
+		plan = cte_inlining.Optimize(std::move(plan));
 	}
-	Optimizer cte_opt(binder, context);
-	CTEInlining cte_inlining(cte_opt);
-	plan = cte_inlining.Optimize(std::move(plan));
+	return has_bound_aggregate_filter;
 }
 
 string QualifyCreateSourceTable(const string &table_name, const string &current_catalog, const string &current_schema,
@@ -314,12 +329,7 @@ static string CollectCreateMVPlanFacts(LogicalOperator *op, const string &curren
 		seen_agg_above = true;
 		auto &agg = op->Cast<LogicalAggregate>();
 		facts.aggregates.push_back(&agg);
-		for (auto &expr : agg.expressions) {
-			if (expr->expression_class == ExpressionClass::BOUND_AGGREGATE &&
-			    expr->Cast<BoundAggregateExpression>().filter) {
-				facts.has_bound_aggregate_filter = true;
-			}
-		}
+		facts.has_bound_aggregate_filter = facts.has_bound_aggregate_filter || HasBoundAggregateFilter(agg);
 	} else if (op->type == LogicalOperatorType::LOGICAL_UNION) {
 		if (!seen_agg_above) {
 			facts.has_union_before_aggregate = true;
@@ -1465,128 +1475,91 @@ static bool ResolveBindingToOccurrenceRefs(ColumnBinding binding, const CreateMV
 	return ResolveBindingToOccurrenceRefsInternal(binding, facts, out, 0);
 }
 
-static void CollectInnerJoinEdgesOccurrence(LogicalOperator *op, const CreateMVPlanFacts &facts,
-                                            vector<WindowEquivalenceEdge> &edges) {
-	if (op->type == LogicalOperatorType::LOGICAL_COMPARISON_JOIN ||
-	    op->type == LogicalOperatorType::LOGICAL_ASOF_JOIN) {
-		auto &join = op->Cast<LogicalComparisonJoin>();
+static void CollectWindowJoinEdges(LogicalComparisonJoin &join, const CreateMVPlanFacts &facts,
+                                   vector<WindowEquivalenceEdge> &equivalence_edges,
+                                   vector<WindowLookupEdge> &lookup_edges) {
+	if (join.type != LogicalOperatorType::LOGICAL_COMPARISON_JOIN &&
+	    join.type != LogicalOperatorType::LOGICAL_ASOF_JOIN) {
+		return;
+	}
+	auto add_lookup_edge = [&](OccurrenceColumnRef lookup_ref, string lookup_cast, OccurrenceColumnRef changed_ref,
+	                           string changed_cast) {
+		lookup_edges.push_back(
+		    {std::move(lookup_ref), std::move(lookup_cast), std::move(changed_ref), std::move(changed_cast)});
+	};
+	for (auto &condition : join.conditions) {
+		if (condition.comparison != ExpressionType::COMPARE_EQUAL) {
+			continue;
+		}
+		string left_cast;
+		string right_cast;
+		auto *left = GetColumnRefThroughCasts(condition.left.get(), &left_cast);
+		auto *right = GetColumnRefThroughCasts(condition.right.get(), &right_cast);
+		if (!left || !right) {
+			continue;
+		}
+		OccurrenceColumnRef left_ref, right_ref;
+		if (!ResolveBindingToOccurrenceRefWithCast(left->binding, facts, left_ref, left_cast, left->return_type) ||
+		    !ResolveBindingToOccurrenceRefWithCast(right->binding, facts, right_ref, right_cast,
+		                                           right->return_type)) {
+			continue;
+		}
+		switch (join.join_type) {
+		case JoinType::INNER:
+		case JoinType::LEFT:
+			add_lookup_edge(left_ref, left_cast, right_ref, right_cast);
+			add_lookup_edge(right_ref, right_cast, left_ref, left_cast);
+			break;
+		case JoinType::RIGHT:
+			add_lookup_edge(right_ref, right_cast, left_ref, left_cast);
+			add_lookup_edge(left_ref, left_cast, right_ref, right_cast);
+			break;
+		default:
+			break;
+		}
 		if (join.join_type == JoinType::INNER) {
-			for (auto &cond : join.conditions) {
-				if (cond.comparison != ExpressionType::COMPARE_EQUAL) {
-					continue;
-				}
-				string left_cast;
-				string right_cast;
-				auto *left = GetColumnRefThroughCasts(cond.left.get(), &left_cast);
-				auto *right = GetColumnRefThroughCasts(cond.right.get(), &right_cast);
-				if (!left || !right) {
-					continue;
-				}
-				OccurrenceColumnRef lref, rref;
-				if (ResolveBindingToOccurrenceRefWithCast(left->binding, facts, lref, left_cast, left->return_type) &&
-				    ResolveBindingToOccurrenceRefWithCast(right->binding, facts, rref, right_cast,
-				                                          right->return_type)) {
-					edges.push_back({std::move(lref), std::move(left_cast), std::move(rref), std::move(right_cast)});
-				}
-			}
+			equivalence_edges.push_back(
+			    {std::move(left_ref), std::move(left_cast), std::move(right_ref), std::move(right_cast)});
 		}
-	}
-	for (auto &child : op->children) {
-		CollectInnerJoinEdgesOccurrence(child.get(), facts, edges);
 	}
 }
 
-static void CollectWindowLookupEdges(LogicalOperator *op, const CreateMVPlanFacts &facts,
-                                     vector<WindowLookupEdge> &edges) {
-	if (op->type == LogicalOperatorType::LOGICAL_COMPARISON_JOIN ||
-	    op->type == LogicalOperatorType::LOGICAL_ASOF_JOIN) {
-		auto &join = op->Cast<LogicalComparisonJoin>();
-		auto add_lookup_edge = [&](OccurrenceColumnRef lookup_ref, string lookup_cast, OccurrenceColumnRef changed_ref,
-		                           string changed_cast) {
-			edges.push_back(
-			    {std::move(lookup_ref), std::move(lookup_cast), std::move(changed_ref), std::move(changed_cast)});
-		};
-		for (auto &cond : join.conditions) {
-			if (cond.comparison != ExpressionType::COMPARE_EQUAL) {
-				continue;
-			}
-			string left_cast;
-			string right_cast;
-			auto *left = GetColumnRefThroughCasts(cond.left.get(), &left_cast);
-			auto *right = GetColumnRefThroughCasts(cond.right.get(), &right_cast);
-			if (!left || !right) {
-				continue;
-			}
-			OccurrenceColumnRef lref, rref;
-			if (!ResolveBindingToOccurrenceRefWithCast(left->binding, facts, lref, left_cast, left->return_type) ||
-			    !ResolveBindingToOccurrenceRefWithCast(right->binding, facts, rref, right_cast, right->return_type)) {
-				continue;
-			}
-			switch (join.join_type) {
-			case JoinType::INNER:
-				add_lookup_edge(lref, left_cast, rref, right_cast);
-				add_lookup_edge(rref, right_cast, lref, left_cast);
-				break;
-			case JoinType::LEFT:
-				add_lookup_edge(lref, left_cast, rref, right_cast);
-				add_lookup_edge(rref, right_cast, lref, left_cast);
-				break;
-			case JoinType::RIGHT:
-				add_lookup_edge(rref, right_cast, lref, left_cast);
-				add_lookup_edge(lref, left_cast, rref, right_cast);
-				break;
-			default:
-				break;
-			}
-		}
-	}
-	for (auto &child : op->children) {
-		CollectWindowLookupEdges(child.get(), facts, edges);
-	}
-}
-
-static void CollectWindowPartitionRefs(LogicalOperator *op, const CreateMVPlanFacts &facts,
+static void CollectWindowPartitionRefs(LogicalWindow &window, const CreateMVPlanFacts &facts,
                                        const vector<string> &partition_columns, vector<WindowLineageOp> &direct_ops) {
-	if (op->type == LogicalOperatorType::LOGICAL_WINDOW) {
-		auto &window = op->Cast<LogicalWindow>();
-		for (auto &expr : window.expressions) {
-			if (expr->expression_class != ExpressionClass::BOUND_WINDOW) {
+	for (auto &expression : window.expressions) {
+		if (expression->expression_class != ExpressionClass::BOUND_WINDOW) {
+			continue;
+		}
+		auto &window_expression = expression->Cast<BoundWindowExpression>();
+		for (auto &partition : window_expression.partitions) {
+			string partition_cast;
+			auto *column_ref = GetColumnRefThroughCasts(partition.get(), &partition_cast);
+			if (!column_ref) {
 				continue;
 			}
-			auto &win_expr = expr->Cast<BoundWindowExpression>();
-			for (auto &part : win_expr.partitions) {
-				string partition_cast;
-				auto *bcr = GetColumnRefThroughCasts(part.get(), &partition_cast);
-				if (!bcr) {
-					continue;
-				}
-				vector<OccurrenceColumnRef> refs;
-				if (!ResolveBindingToOccurrenceRefs(bcr->binding, facts, refs)) {
-					continue;
-				}
-				for (auto &ref : refs) {
-					for (auto &stored : partition_columns) {
-						auto pos = stored.find('=');
-						string output_col = pos == string::npos ? stored : stored.substr(0, pos);
-						string source_col = pos == string::npos ? stored : stored.substr(pos + 1);
-						if (!StringUtil::CIEquals(source_col, ref.column)) {
-							continue;
-						}
-						WindowLineageOp op;
-						op.kind = "direct";
-						op.output_col = output_col;
-						op.source_table = ref.table;
-						op.source_occurrence = ref.occurrence;
-						op.source_col = ref.column;
-						op.source_cast = partition_cast;
-						direct_ops.push_back(std::move(op));
+			vector<OccurrenceColumnRef> refs;
+			if (!ResolveBindingToOccurrenceRefs(column_ref->binding, facts, refs)) {
+				continue;
+			}
+			for (auto &ref : refs) {
+				for (auto &stored : partition_columns) {
+					auto pos = stored.find('=');
+					string output_col = pos == string::npos ? stored : stored.substr(0, pos);
+					string source_col = pos == string::npos ? stored : stored.substr(pos + 1);
+					if (!StringUtil::CIEquals(source_col, ref.column)) {
+						continue;
 					}
+					WindowLineageOp op;
+					op.kind = "direct";
+					op.output_col = output_col;
+					op.source_table = ref.table;
+					op.source_occurrence = ref.occurrence;
+					op.source_col = ref.column;
+					op.source_cast = partition_cast;
+					direct_ops.push_back(std::move(op));
 				}
 			}
 		}
-	}
-	for (auto &child : op->children) {
-		CollectWindowPartitionRefs(child.get(), facts, partition_columns, direct_ops);
 	}
 }
 
@@ -1651,13 +1624,14 @@ bool BuildWindowPartitionLineageOps(const CreateMVPlanFacts &facts, const vector
 	if (!facts.root || partition_columns.empty()) {
 		return false;
 	}
-	auto *plan = facts.root;
 	if (facts.source_occurrences.empty()) {
 		return false;
 	}
 
 	vector<WindowLineageOp> direct_ops;
-	CollectWindowPartitionRefs(plan, facts, partition_columns, direct_ops);
+	for (auto *window : facts.windows) {
+		CollectWindowPartitionRefs(*window, facts, partition_columns, direct_ops);
+	}
 	if (direct_ops.empty()) {
 		return false;
 	}
@@ -1668,9 +1642,10 @@ bool BuildWindowPartitionLineageOps(const CreateMVPlanFacts &facts, const vector
 	}
 
 	vector<WindowEquivalenceEdge> edges;
-	CollectInnerJoinEdgesOccurrence(plan, facts, edges);
 	vector<WindowLookupEdge> lookup_edges;
-	CollectWindowLookupEdges(plan, facts, lookup_edges);
+	for (auto *join : facts.comparison_joins) {
+		CollectWindowJoinEdges(*join, facts, edges, lookup_edges);
+	}
 
 	vector<WindowLineageOp> partition_ops;
 	for (auto &op : direct_ops) {

--- a/src/core/parser_plan_helpers.cpp
+++ b/src/core/parser_plan_helpers.cpp
@@ -300,9 +300,14 @@ static void AddGetFacts(LogicalGet &get, const string &current_catalog, CreateMV
 
 static string CollectCreateMVPlanFacts(LogicalOperator *op, const string &current_catalog, CreateMVPlanFacts &facts,
                                        unordered_map<string, idx_t> &next_occurrence, bool seen_agg_above,
-                                       bool under_join) {
+                                       bool under_join, const LogicalOperator *redundant_distinct,
+                                       PlanAnalysis &analysis) {
 	if (!op) {
 		return "";
+	}
+	AnalyzePlanOperator(*op, analysis);
+	if (redundant_distinct && op != redundant_distinct && op->type == LogicalOperatorType::LOGICAL_DISTINCT) {
+		facts.has_descendant_distinct = true;
 	}
 	string first_table;
 	if (op->type == LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY) {
@@ -413,11 +418,29 @@ static string CollectCreateMVPlanFacts(LogicalOperator *op, const string &curren
 		facts.first_table_name[op] = first_table;
 		return first_table;
 	}
-	for (auto &child : op->children) {
-		string child_first =
-		    CollectCreateMVPlanFacts(child.get(), current_catalog, facts, next_occurrence, seen_agg_above, under_join);
+	auto collect_child = [&](LogicalOperator *child, PlanAnalysis &child_analysis) {
+		string child_first = CollectCreateMVPlanFacts(child, current_catalog, facts, next_occurrence, seen_agg_above,
+		                                             under_join, redundant_distinct, child_analysis);
 		if (first_table.empty()) {
 			first_table = std::move(child_first);
+		}
+	};
+	if (op->type == LogicalOperatorType::LOGICAL_MATERIALIZED_CTE) {
+		PlanAnalysis body_analysis;
+		if (!op->children.empty()) {
+			collect_child(op->children[0].get(), body_analysis);
+		}
+		if (op->children.size() >= 2) {
+			collect_child(op->children[1].get(), analysis);
+			MergeMaterializedCteBodyAnalysis(analysis, std::move(body_analysis));
+		}
+		for (idx_t i = 2; i < op->children.size(); i++) {
+			PlanAnalysis ignored_analysis;
+			collect_child(op->children[i].get(), ignored_analysis);
+		}
+	} else {
+		for (auto &child : op->children) {
+			collect_child(child.get(), analysis);
 		}
 	}
 	if (!first_table.empty()) {
@@ -1066,22 +1089,9 @@ bool IsRedundantDistinctOverGroupKeys(LogicalOperator &node) {
 	return true;
 }
 
-static bool HasDistinctOperator(const LogicalOperator &node) {
-	if (node.type == LogicalOperatorType::LOGICAL_DISTINCT) {
-		return true;
-	}
-	for (auto &child : node.children) {
-		if (HasDistinctOperator(*child)) {
-			return true;
-		}
-	}
-	return false;
-}
-
 CreateMVPlanFacts BuildCreateMVPlanFacts(LogicalOperator *plan, const string &current_catalog) {
 	CreateMVPlanFacts facts;
 	facts.root = plan;
-	facts.analysis = AnalyzePlan(plan);
 	LogicalOperator *top = plan;
 	while (top && top->children.size() == 1 &&
 	       (top->type == LogicalOperatorType::LOGICAL_CREATE_TABLE ||
@@ -1093,11 +1103,9 @@ CreateMVPlanFacts BuildCreateMVPlanFacts(LogicalOperator *plan, const string &cu
 	facts.has_top_level_redundant_distinct =
 	    top && top->type == LogicalOperatorType::LOGICAL_DISTINCT && !top->children.empty() &&
 	    (ProducesAtMostOneRow(*top->children[0]) || IsRedundantDistinctOverGroupKeys(*top));
-	if (facts.has_top_level_redundant_distinct) {
-		facts.has_descendant_distinct = HasDistinctOperator(*top->children[0]);
-	}
 	unordered_map<string, idx_t> next_occurrence;
-	CollectCreateMVPlanFacts(plan, current_catalog, facts, next_occurrence, false, false);
+	CollectCreateMVPlanFacts(plan, current_catalog, facts, next_occurrence, false, false,
+	                         facts.has_top_level_redundant_distinct ? top : nullptr, facts.analysis);
 	FinalizeCreateMVPlanFacts(facts);
 	AddJoinEdgesFromFacts(facts);
 	return facts;

--- a/src/core/parser_plan_helpers.cpp
+++ b/src/core/parser_plan_helpers.cpp
@@ -68,41 +68,28 @@ string BuildTopKSuffix(const vector<BoundOrderByNode> &orders, idx_t limit_val, 
 	return sql;
 }
 
-static bool PlanContainsCte(LogicalOperator *op) {
+static bool PrepareCtesForInlining(LogicalOperator *op) {
 	if (!op) {
 		return false;
 	}
-	if (op->type == LogicalOperatorType::LOGICAL_CTE_REF || op->type == LogicalOperatorType::LOGICAL_MATERIALIZED_CTE) {
-		return true;
-	}
-	for (auto &child : op->children) {
-		if (PlanContainsCte(child.get())) {
-			return true;
-		}
-	}
-	return false;
-}
-
-static void RelaxMaterializedCtes(LogicalOperator *op) {
-	if (!op) {
-		return;
-	}
+	bool found_cte = op->type == LogicalOperatorType::LOGICAL_CTE_REF;
 	if (op->type == LogicalOperatorType::LOGICAL_MATERIALIZED_CTE) {
+		found_cte = true;
 		auto &cte = op->Cast<LogicalMaterializedCTE>();
 		if (cte.materialize == CTEMaterialize::CTE_MATERIALIZE_ALWAYS) {
 			cte.materialize = CTEMaterialize::CTE_MATERIALIZE_DEFAULT;
 		}
 	}
 	for (auto &child : op->children) {
-		RelaxMaterializedCtes(child.get());
+		found_cte = PrepareCtesForInlining(child.get()) || found_cte;
 	}
+	return found_cte;
 }
 
 void InlineCtesIfPresent(ClientContext &context, Binder &binder, unique_ptr<LogicalOperator> &plan) {
-	if (!PlanContainsCte(plan.get())) {
+	if (!PrepareCtesForInlining(plan.get())) {
 		return;
 	}
-	RelaxMaterializedCtes(plan.get());
 	Optimizer cte_opt(binder, context);
 	CTEInlining cte_inlining(cte_opt);
 	plan = cte_inlining.Optimize(std::move(plan));
@@ -2041,54 +2028,22 @@ static bool IsAggregateFunctionUnsupportedByLpts(const string &fn_name) {
 	       fn_name == "arg_min" || fn_name == "arg_max";
 }
 
-bool QueryNeedsOriginalSqlForLpts(const string &query) {
-	string lower = StringUtil::Lower(query);
-	return lower.find("pivot ") != string::npos || lower.find("(pivot ") != string::npos;
-}
-
-bool PlanNeedsOriginalSqlForLpts(LogicalOperator *op) {
-	if (!op) {
-		return false;
-	}
-	if (op->type == LogicalOperatorType::LOGICAL_PIVOT) {
+bool PlanNeedsOriginalSqlForLpts(const CreateMVPlanFacts &facts) {
+	if (facts.has_pivot) {
 		return true;
 	}
-	if (op->type == LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY) {
-		auto *agg = dynamic_cast<LogicalAggregate *>(op);
-		if (agg) {
-			for (auto &expr : agg->expressions) {
-				if (expr->type != ExpressionType::BOUND_AGGREGATE) {
-					continue;
-				}
-				auto &bound_agg = expr->Cast<BoundAggregateExpression>();
-				if (IsAggregateFunctionUnsupportedByLpts(bound_agg.function.name)) {
-					return true;
-				}
+	for (auto *aggregate : facts.aggregates) {
+		for (auto &expr : aggregate->expressions) {
+			if (expr->type != ExpressionType::BOUND_AGGREGATE) {
+				continue;
+			}
+			auto &bound_agg = expr->Cast<BoundAggregateExpression>();
+			if (IsAggregateFunctionUnsupportedByLpts(bound_agg.function.name)) {
+				return true;
 			}
 		}
 	}
-	for (auto &child : op->children) {
-		if (PlanNeedsOriginalSqlForLpts(child.get())) {
-			return true;
-		}
-	}
 	return false;
-}
-
-LogicalAggregate *FindOuterAggregate(LogicalOperator *op) {
-	if (!op) {
-		return nullptr;
-	}
-	if (op->type == LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY) {
-		return &op->Cast<LogicalAggregate>();
-	}
-	for (auto &child : op->children) {
-		auto *aggregate = FindOuterAggregate(child.get());
-		if (aggregate) {
-			return aggregate;
-		}
-	}
-	return nullptr;
 }
 
 bool IsPacLoaded(ClientContext &context) {

--- a/src/include/core/incremental_checker.hpp
+++ b/src/include/core/incremental_checker.hpp
@@ -55,10 +55,13 @@ struct PlanAnalysis {
 	idx_t group_index = DConstants::INVALID_INDEX; // aggregate's group_index for binding lookup
 };
 
-/// Walk the logical plan tree once, validating IVM compatibility AND extracting
-/// metadata (aggregation type, join type, group-by columns, etc.).
-/// Replaces separate compatibility and metadata walks.
-PlanAnalysis AnalyzePlan(LogicalOperator *plan);
+/// Add one operator's compatibility and classification metadata to the plan analysis.
+/// Tree traversal is owned by BuildCreateMVPlanFacts so analysis and lineage are collected together.
+void AnalyzePlanOperator(LogicalOperator &op, PlanAnalysis &analysis);
+
+/// Merge an already-analyzed materialized CTE body after its outer consumer has been analyzed.
+/// The body supplies the query shape only for a pass-through consumer; otherwise only safety facts propagate.
+void MergeMaterializedCteBodyAnalysis(PlanAnalysis &analysis, PlanAnalysis body_analysis);
 
 } // namespace duckdb
 

--- a/src/include/core/incremental_checker.hpp
+++ b/src/include/core/incremental_checker.hpp
@@ -41,9 +41,9 @@ struct PlanAnalysis {
 	vector<string> aggregate_columns;
 	vector<string> aggregate_types;          // per-column: "min", "max", "sum", "count_star", "count", "avg", "list"
 	vector<string> window_partition_columns; // PARTITION BY source columns from window functions
-	vector<string> window_order_columns;           // Common simple ORDER BY columns for all window expressions
-	bool window_row_key_compatible = true;         // False when window expressions use different/non-column keys
-	size_t group_count = 0;                        // number of GROUP BY expressions
+	vector<string> window_order_columns;     // Common simple ORDER BY columns for all window expressions
+	bool window_row_key_compatible = true;   // False when window expressions use different/non-column keys
+	size_t group_count = 0;                  // number of GROUP BY expressions
 	idx_t group_index = DConstants::INVALID_INDEX; // aggregate's group_index for binding lookup
 };
 

--- a/src/include/core/incremental_checker.hpp
+++ b/src/include/core/incremental_checker.hpp
@@ -27,7 +27,6 @@ struct PlanAnalysis {
 	bool found_positional_join = false;
 	bool found_sample = false;
 	bool found_window = false;
-	bool found_top_k = false;
 	bool found_count_distinct = false;   // COUNT(DISTINCT x) — handled via group-recompute
 	bool found_grouping_sets = false;    // ROLLUP/CUBE/GROUPING SETS — handled via RECOMPUTE
 	bool found_nested_aggregate = false; // outer aggregate over inner aggregate (CTE re-agg); COUNT(*) in outer is
@@ -39,16 +38,9 @@ struct PlanAnalysis {
 	bool found_unsupported_join_type = false;
 	bool found_unsupported_order_by = false;
 	bool found_unsupported_operator = false;
-	idx_t top_k_limit = 0;                  // constant LIMIT value from LOGICAL_TOP_N
-	idx_t top_k_offset = 0;                 // OFFSET value (0 if none)
-	vector<string> top_k_order_columns;     // ORDER BY column names (in order) for the top-k
-	vector<bool> top_k_order_desc;          // parallel to top_k_order_columns; true = DESC
-	vector<string> top_k_partition_columns; // PARTITION BY cols for per-partition top-k via ROW_NUMBER ≤ k pattern;
-	                                        // empty for global top-k
 	vector<string> aggregate_columns;
 	vector<string> aggregate_types;          // per-column: "min", "max", "sum", "count_star", "count", "avg", "list"
 	vector<string> window_partition_columns; // PARTITION BY source columns from window functions
-	vector<idx_t> window_partition_column_indexes; // Output-position hint for each PARTITION BY column
 	vector<string> window_order_columns;           // Common simple ORDER BY columns for all window expressions
 	bool window_row_key_compatible = true;         // False when window expressions use different/non-column keys
 	size_t group_count = 0;                        // number of GROUP BY expressions

--- a/src/include/core/incremental_checker.hpp
+++ b/src/include/core/incremental_checker.hpp
@@ -57,11 +57,8 @@ struct PlanAnalysis {
 
 /// Walk the logical plan tree once, validating IVM compatibility AND extracting
 /// metadata (aggregation type, join type, group-by columns, etc.).
-/// Replaces the separate ValidateIncrementalPlan + parser stack walk.
+/// Replaces separate compatibility and metadata walks.
 PlanAnalysis AnalyzePlan(LogicalOperator *plan);
-
-/// Thin wrapper for backward compatibility. Returns true if the plan is fully IVM-compatible.
-bool ValidateIncrementalPlan(LogicalOperator *plan);
 
 } // namespace duckdb
 

--- a/src/include/core/parser_plan_helpers.hpp
+++ b/src/include/core/parser_plan_helpers.hpp
@@ -92,7 +92,8 @@ struct CreateMVPlanFacts {
 
 string BuildTopKSuffix(const vector<BoundOrderByNode> &orders, idx_t limit_val, idx_t offset_val,
                        const vector<string> &output_col_names, bool include_limit = true);
-void InlineCtesIfPresent(ClientContext &context, Binder &binder, unique_ptr<LogicalOperator> &plan);
+/// Inline eligible CTEs and return whether the input plan contained a bound aggregate FILTER.
+bool InlineCtesIfPresent(ClientContext &context, Binder &binder, unique_ptr<LogicalOperator> &plan);
 string QualifyCreateSourceTable(const string &table_name, const string &current_catalog, const string &current_schema,
                                 const string &default_db);
 string ExplainInitialLoadQuery(Connection &con, const string &label, const string &query);

--- a/src/include/core/parser_plan_helpers.hpp
+++ b/src/include/core/parser_plan_helpers.hpp
@@ -129,13 +129,11 @@ bool BuildProjectionKeyLineage(const CreateMVPlanFacts &facts, const vector<stri
                                RefreshMetadata::ProjectionKeyLineage &out);
 bool BuildLeftJoinKeySource(const CreateMVPlanFacts &facts, RefreshMetadata::LeftJoinKeySource &out);
 bool BuildLeftJoinNullableSources(const CreateMVPlanFacts &facts, RefreshMetadata::LeftJoinNullableSources &out);
-bool QueryNeedsOriginalSqlForLpts(const string &query);
-bool PlanNeedsOriginalSqlForLpts(LogicalOperator *op);
+bool PlanNeedsOriginalSqlForLpts(const CreateMVPlanFacts &facts);
 void ResolveAggregateGroupColumnsThroughJoinKeys(const CreateMVPlanFacts &facts, vector<string> &aggregate_columns,
                                                  const vector<string> &output_names);
 string ExtractFullOuterJoinMetadata(const CreateMVPlanFacts &facts);
 vector<string> PrepareOutputNames(LogicalOperator *select_plan, const vector<string> &planner_names);
-LogicalAggregate *FindOuterAggregate(LogicalOperator *op);
 bool IsPacLoaded(ClientContext &context);
 void ForwardPacSettingsIfLoaded(ClientContext &context, Connection &con);
 

--- a/src/include/core/parser_plan_helpers.hpp
+++ b/src/include/core/parser_plan_helpers.hpp
@@ -58,7 +58,6 @@ struct CreateMVPlanFacts {
 	unordered_map<string, SourceTableInfo> source_table_info;
 	unordered_map<string, DuckLakeSourceTableInfo> ducklake_table_info;
 	LogicalProjection *first_projection = nullptr;
-	LogicalComparisonJoin *first_comparison_join = nullptr;
 	vector<LogicalProjection *> projections;
 	vector<LogicalAggregate *> aggregates;
 	vector<LogicalComparisonJoin *> comparison_joins;
@@ -82,7 +81,8 @@ struct CreateMVPlanFacts {
 	bool has_repeated_cte_ref_under_join = false;
 	bool has_pivot = false;
 	bool has_filter_above_aggregate = false;
-	bool has_bound_aggregate_filter = false;
+	bool has_cardinality_changing_filter = false;
+	idx_t outer_join_count = 0;
 	bool has_hidden_minmax_having_column = false;
 	bool has_computed_minmax_aggregate_projection = false;
 	bool has_computed_sum_aggregate_projection = false;


### PR DESCRIPTION
## Summary\n\n- collect compatibility/classification metadata during the existing materialized-view facts traversal\n- preserve materialized-CTE outer-first classification while retaining body-first lineage/source collection\n- fold descendant-DISTINCT detection into the unified traversal\n- collect pre-rewrite aggregate-FILTER presence during the existing CTE-preparation walk\n- build window partition and join lineage from already-collected window/join facts instead of three recursive walks\n- collect outer-join counts and cardinality-changing-filter presence in the unified facts traversal, removing two more plan walks\n- remove write-only top-k and window-index analysis metadata\n- remove duplicated first-comparison-join and aggregate-filter facts\n- reuse CreateMVPlanFacts for LPTS fallback and outer-aggregate inspection\n- combine CTE detection and materialization relaxation into one plan traversal\n- remove obsolete query-text PIVOT detection and unused compatibility helpers\n- correct 76 standalone-LIMIT classifications in both TPC-C metadata trees\n\nNet change: 401 additions, 534 deletions (-133 LOC), including 152 line-for-line metadata replacements. The final cleanup batch is -102 LOC.\n\n## Testing\n\n- cmake --build build/release\n- build/release/test/unittest test/sql/cte.test\n- build/release/test/unittest test/sql/window.test\n- build/release/test/unittest test/sql/projection.test\n- build/release/test/unittest test/sql/aggregate.test\n- build/release/test/unittest test/sql/left_join.test\n- build/release/test/unittest test/sql/left_join_deep_chain_secondary.test\n- build/release/test/unittest test/sql/left_join_emptied_group.test\n- build/release/test/unittest test/sql/left_join_group_by_join_key.test\n- build/release/test/unittest test/sql/left_join_pipeline_secondary_delta.test\n- build/release/test/unittest test/sql/left_join_preserved_append.test\n- build/release/test/unittest test/sql/full_outer_join.test\n- additional earlier coverage: distinct, full-refresh, list, recursive-rewriter, and joined-window cascade suites\n- fresh SF1 rewriter benchmark: 2502/2502 completed queries correct; classifications matched metadata 100%\n- three extreme DuckLake queries hit the full-suite 30-second timeout; all three passed isolated with 100% correctness and metadata agreement\n- mixed INSERT + UPDATE + DELETE before one refresh on materialized-CTE aggregate, FILTER aggregate, and joined partitioned-window views, with EXCEPT ALL in both directions\n- git diff --check\n\n## Note\n\nmake format-fix could not run locally because the repository requires clang-format 11 while clang-format 22.1.8 is installed; the diff check is clean.